### PR TITLE
Switch to using direct SQL To see if that works any better to remove …

### DIFF
--- a/civigeometry.php
+++ b/civigeometry.php
@@ -189,13 +189,9 @@ function civigeometry_symfony_civicrm_post($event) {
     $id = $hookValues[2];
     $address = civicrm_api3('Address', 'get', ['id' => $id])['values'][$id];
     if (!empty($address['geo_code_2']) && !empty($address['geo_code_1'])) {
-      $dao = new CRM_CiviGeometry_DAO_AddressGeometry();
-      $dao->address_id = $id;
-      if ($dao->find()) {
-        while ($dao->fetch()) {
-          $dao->delete();
-        }
-      }
+      CRM_Core_DAO::executeQuery("DELETE FROM civigeometry_address_geometry WHERE address_id = %1", [
+        1 => [$address['id'], 'Positive'],
+      ]);
       $geometry_ids = civicrm_api3('Geometry', 'contains', [
         'geometry_a' => 0,
         'geometry_b' => 'POINT(' . $address['geo_code_2'] . ' ' . $address['geo_code_1'] . ')',


### PR DESCRIPTION
…rrows from address_geometry

I tested this with contact_id 533183 on dev and confirmed i was able to successfully submit a new membership for the person. In most cases we have just a postcode for an address and then are submitting a membership and filling in more details about the address in the edit membership screen. I believe this will do what we want