### PR TITLE
Fix/linting

### DIFF
--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -214,7 +214,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
    *   - geometry_a
    *   - geometry_b
    */
-  public static function getGeometryIntesection($params) {
+  public static function getGeometryIntersection($params) {
     $values = [];
     if (!empty($params['collection_id'])) {
       $select_table = 'b';

--- a/api/v3/Geometry.php
+++ b/api/v3/Geometry.php
@@ -455,7 +455,7 @@ function civicrm_api3_geometry_getintersection($params) {
   }
   // Check that we have either the other geometry or a collection id.
   civicrm_api3_verify_one_mandatory($params, NULL, ['geometry_' . $test, 'collection_id']);
-  $result = CRM_CiviGeometry_BAO_Geometry::getGeometryIntesection($params);
+  $result = CRM_CiviGeometry_BAO_Geometry::getGeometryIntersection($params);
   return civicrm_api3_create_success($result, $params);
 }
 

--- a/api/v3/Geometry.php
+++ b/api/v3/Geometry.php
@@ -165,7 +165,7 @@ function civicrm_api3_geometry_get($params) {
  * @throws API_Exception
  */
 function civicrm_api3_geometry_getcollection($params) {
-  return _civicrm_api3_basic_get('CRM_CiviGeometry_BAO_GeometryCollectionGeometry', $params);
+  return _civicrm_api3_basic_get('CRM_CiviGeometry_DAO_GeometryCollectionGeometry', $params);
 }
 
 /**


### PR DESCRIPTION
Renames a function to fix a spelling mistake and modifies the `getcollection` function in the API to reference the DAO rather than BAO (as identified by failling unit tests).