### PR TITLE
Remove cache expiry in query

### DIFF
--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -276,7 +276,6 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
     $checkCache = new CRM_CiviGeometry_DAO_GeometryOverlapCache();
     $checkCache->geometry_id_a = $params['geometry_id_a'];
     $checkCache->geometry_id_b = $params['geometry_id_b'];
-    $checkCache->addWhere("cache_date >= DATE_SUB(NOW(), INTERVAL 1 Month)");
     $checkCache->find();
     if ($checkCache->N == 1) {
       while ($checkCache->fetch()) {


### PR DESCRIPTION
This PR removes the check of an expiry date for cached overlap records. The reasoning being overlaps never expire unless the geometries themselves change. Given the extension has the `is_archived` flag for recording when a geometry is no longer in use, time-based cache expiry isn't necessary.

A subsequent PR will look to add cache clearing functionality so that when a geometry is archived any corresponding cache entries are also removed.