### PR TITLE
Fix/address geom memory exhaustion

### DIFF
--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -571,7 +571,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
         $offset += $params['batch_size'];
       }
       else {
-        throw new Exception("count <= 0, but haven't finish yet. That doesn't make any sense");
+        throw new CRM_Core_ExecptionException(E::ts("No candidate addresses, but batches still remaining to process. That doesn't make any sense."));
       }
     }
   }

--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -462,7 +462,8 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
     $tmpTbl = CRM_Utils_SQL_TempTable::build();
     if ($params['keep_temp_table']) {
       $tmpTbl->setDurable();
-    } else {
+    }
+    else {
       $tmpTbl->setAutodrop(true);
     }
     $tmpTbl->createWithColumns('address_id INT');
@@ -495,7 +496,8 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
         4 => [$bounds['bottom_bound'], 'Float'],
         5 => [$geometry_id, 'Integer']
       ]);
-    } else {
+    }
+    else {
       CRM_Core_DAO::executeQuery("
         INSERT INTO $tempTableName (address_id)
         SELECT ca.id
@@ -567,13 +569,11 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
         }
 
         $offset += $params['batch_size'];
-      } else {
+      }
+      else {
         throw new Exception("count <= 0, but haven't finish yet. That doesn't make any sense");
       }
     }
-
-    // TODO: Probably not necessary since autodrop is set?
-    if (!$params['keep_temp_table']) $tmpTbl->drop();
   }
 
   /**

--- a/CRM/CiviGeometry/Tasks.php
+++ b/CRM/CiviGeometry/Tasks.php
@@ -48,7 +48,7 @@ class CRM_CiviGeometry_Tasks {
    * Get all the Addresses for this geometry
    */
   public static function buildGeometryRelationships(CRM_Queue_TaskContext $ctx, $geometry_id) {
-    foreach (CRM_CiviGeometry_BAO_Geometry::getAddresses($geometry_id, []) as $match) {
+    foreach (CRM_CiviGeometry_BAO_Geometry::getAddresses($geometry_id) as $match) {
       civicrm_api3('Address', 'creategeometries', [
         'geometry_id' => $match['geometry_id'],
         'address_id' => $match['address_id'],

--- a/CRM/CiviGeometry/Tasks.php
+++ b/CRM/CiviGeometry/Tasks.php
@@ -48,8 +48,7 @@ class CRM_CiviGeometry_Tasks {
    * Get all the Addresses for this geometry
    */
   public static function buildGeometryRelationships(CRM_Queue_TaskContext $ctx, $geometry_id) {
-    $matches = CRM_CiviGeometry_BAO_Geometry::getAddresses($geometry_id);
-    foreach ($matches as $match) {
+    foreach (getAddressesAsGenerator($params['geometry_id'], []) as $match) {
       civicrm_api3('Address', 'creategeometries', [
         'geometry_id' => $match['geometry_id'],
         'address_id' => $match['address_id'],

--- a/CRM/CiviGeometry/Tasks.php
+++ b/CRM/CiviGeometry/Tasks.php
@@ -48,7 +48,7 @@ class CRM_CiviGeometry_Tasks {
    * Get all the Addresses for this geometry
    */
   public static function buildGeometryRelationships(CRM_Queue_TaskContext $ctx, $geometry_id) {
-    foreach (getAddressesAsGenerator($params['geometry_id'], []) as $match) {
+    foreach (CRM_CiviGeometry_BAO_Geometry::getAddresses($geometry_id, []) as $match) {
       civicrm_api3('Address', 'creategeometries', [
         'geometry_id' => $match['geometry_id'],
         'address_id' => $match['address_id'],

--- a/api/v3/Address/Getgeometries.php
+++ b/api/v3/Address/Getgeometries.php
@@ -62,7 +62,8 @@ function civicrm_api3_address_getgeometries($params) {
       return civicrm_api3_create_success(0);
     }
     else {
-      return civicrm_api3_create_success(CRM_CiviGeometry_BAO_Geometry::getAddresses($params['geometry_id']), $params);
+      $results = CRM_CiviGeometry_BAO_Geometry::getAddresses($params['geometry_id']);
+      return civicrm_api3_create_success(iterator_to_array($results), $params);
     }
   }
   $params['entity_table'] = 'civicrm_address';


### PR DESCRIPTION
This is a complete refactor of `CRM_CiviGeometry_BAO_Geometry->getAddresses()`, converting it into a generator function.
The iterator that is returned is same as each element of the previously returned array, so only required minor changes to `CRM_CiviGeometry_Tasks::buildGeometryRelationships()`

Basic method:
- Uses a temp table to built up a list of potential _candidates_ that are within the bounds of the geometry (rather than storing results in an array). 
- By default will eliminate civicrm_address entities that already have a relationship with the geometry in civigeometry_geometry_entity table. This can be modified with `$params['precheck_relationships']`
- Fetches from these in batches of 100 (adjustable with `$params['batch_size']`), doing the full ST_Contains check on each as before.