### PR TITLE
Fix/address geom memory exhaustion

### DIFF
--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -441,7 +441,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
    * @param  integer $batchSize     The batch size
    * @return array                  The next batch of civicrm_address ids
    */
-  public static function getAddressesFetchCandidateBatch($candidateTable, $offset, $batchSize) {
+  protected static function getAddressesFetchCandidateBatch($candidateTable, $offset, $batchSize) {
     $dao = CRM_Core_DAO::executeQuery("
       SELECT ct.address_id
       FROM $candidateTable ct
@@ -465,7 +465,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
    * @param  integer $addressId     Id of the civicrm_address
    * @return boolean
    */
-  public static function getAddressesGeometryContainsCandidate($geometryId, $addressId) {
+  protected static function getAddressesGeometryContainsCandidate($geometryId, $addressId) {
     $geomTableName = self::getTableName();
     $select = CRM_Utils_SQL_Select::from($geomTableName . ' g, civicrm_address ca')
       ->select("ST_Contains(g.geometry, ST_GeomFromText(CONCAT('POINT(', ca.geo_code_2, ' ', ca.geo_code_1, ')'), 4326)) AS is_within")
@@ -503,7 +503,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
    *   - keep_temp_table: Boolean. Default FALSE.
    *   - precheck_relationships: Boolean. Default TRUE.
    */
-  private function getAddresses($geometry_id, $params = []) {
+  public function getAddresses($geometry_id, $params = []) {
     $defaultParams = [
       'batch_size' => 100,
       'keep_temp_table' => FALSE,

--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -466,7 +466,8 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
    * @return boolean
    */
   public static function getAddressesGeometryContainsCandidate($geometryId, $addressId) {
-    $select = CRM_Utils_SQL_Select::from(self::getTableName() . ' g, civicrm_address ca')
+    $geomTableName = self::getTableName();
+    $select = CRM_Utils_SQL_Select::from($geomTableName . ' g, civicrm_address ca')
       ->select("ST_Contains(g.geometry, ST_GeomFromText(CONCAT('POINT(', ca.geo_code_2, ' ', ca.geo_code_1, ')'), 4326)) AS is_within")
       ->where("g.id = #geometry_id", ['geometry_id' => $geometryId])
       ->where("ca.id = #address_id", ['address_id' => $addressId]);

--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -466,7 +466,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
    * @return boolean
    */
   public static function getAddressesGeometryContainsCandidate($geometryId, $addressId) {
-    $select = CRM_Utils_SQL_Select::from($self::getTableName() . ' g, civicrm_address ca')
+    $select = CRM_Utils_SQL_Select::from(self::getTableName() . ' g, civicrm_address ca')
       ->select("ST_Contains(g.geometry, ST_GeomFromText(CONCAT('POINT(', ca.geo_code_2, ' ', ca.geo_code_1, ')'), 4326)) AS is_within")
       ->where("g.id = #geometry_id", ['geometry_id' => $geometryId])
       ->where("ca.id = #address_id", ['address_id' => $addressId]);

--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -434,77 +434,166 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
   }
 
   /**
-   * Get an an array of address ids for a specific geometry_id
-   * @param int $geometry_id
-   * @return array
+   * Helper method for getAddresses. Fetches set of address_id values from $candidateTable
+   *
+   * @param  string  $candidateTable The name of the table holding the candidate ids
+   * @param  integer $offset        Current offset
+   * @param  integer $batchSize     The batch size
+   * @return array                  The next batch of civicrm_address ids
    */
-  public static function getAddresses($geometry_id) {
-    $bounds = civicrm_api3('Geometry', 'getbounds', ['id' => $geometry_id])['values'][$geometry_id];
-    // Use a table to store a potentially very large number of addresses
-    // But we are not using a temp table as we may exhaust memory, etc.
-    $tempTableName = CRM_Utils_SQL_TempTable::getName();
-    $query <<<EOQ
-      CREATE TABLE %1
-      SELECT address_id, 0 as is_contained FROM civicrm_address
-      WHERE geo_code_2 >= %2
-      AND geo_code_2 <= %3
-      AND geo_code_1 <= %4
-      AND geo_code_1 >= %5
-      ORDER BY id
-EOQ;
-    CRM_Core_DAO::executeQuery($query, [1 => $tempTableName,
-      2 => $bounds['left_bound'],
-      3 => $bounds['right_bound'],
-      4 => $bounds['top_bound'],
-      5 => $bounds['bottom_bounds'],
-    ]);
-    $numAddresses =  CRM_Core_DAO::singleValueQuery('SELECT COUNT(*) FROM %1', [1 => $tempTableName]);
-    $results = [];
-    if ($numAddresses > 0) {
-      $rowCount = 5000;
-      $numBatches = $numAddresses / $rowCount;
-      $offset = 0;
-      while ( $numBatches-- > 0) {
-        $dao = CRM_Utils_SQL_Select::from('%1', [1 => $tempTableName])
-          ->select('address_id')
-          ->orderBy('address_id')
-          ->limit($rowCount, $offset)
-          ->execute();
-        while ($dao->fetch()) {
-          // Do ST_Contains test
-          // If answer is 1, store id in array
-        }
-        // Update addresses in our temp table
-        // Update offset
-        $offset += $rowCount;
-      }
-      // drop table
-      // return results
-      return $result;
-    }
-    else {
-      return [];
-    }
+  public static function getAddressesFetchCandidateBatch($candidateTable, $offset, $batchSize) {
+    $dao = CRM_Core_DAO::executeQuery("
+        SELECT ct.address_id
+        FROM $candidateTable ct
+        ORDER BY address_id
+        LIMIT %1
+        OFFSET %2
+      ", [
+        1 => [$batchSize, 'Integer'],
+        2 => [$offset, 'Integer'],
+      ]);
+
+      $results = $dao->fetchAll();
+
+      return $results;
   }
 
-    // this block will go once the refactored code above is complete
-    if (!empty($addressResults)) {
-      $address_ids = CRM_Utils_Array::collect('id', $addressResults);
-      foreach ($address_ids as $address_id) {
-        $select = CRM_Utils_SQL_Select::from(self::getTableName() . ' g, civicrm_address ca')
-          ->select("ca.id as address_id, g.id as geometry_id")
-          ->where("ST_Contains(g.geometry, ST_GeomFromText(CONCAT('POINT(', ca.geo_code_2, ' ', ca.geo_code_1, ')'), 4326)) = 1")
-          ->where("g.id = #geometry_id", ['geometry_id' => $geometry_id])
-          ->where("ca.id = #address_id", ['address_id' => $address_id]);
-        $result = CRM_Core_DAO::executeQuery($select->toSQL())->fetchAll();
-        if (!empty($result)) {
-          $results[] = $result[0];
-        }
-      }
-      return $results;
+  /**
+   * Helper method for getAddresses. Checks if specified geometry contains civicrm_address with id.
+   *
+   * @param  integer $geometryId    Id of the geometry to check against
+   * @param  integer $addressId     Id of the civicrm_address
+   * @return boolean
+   */
+  public static function getAddressesGeometryContainsCandidate($geometryId, $addressId) {
+    $select = CRM_Utils_SQL_Select::from($self::getTableName() . ' g, civicrm_address ca')
+      ->select("ST_Contains(g.geometry, ST_GeomFromText(CONCAT('POINT(', ca.geo_code_2, ' ', ca.geo_code_1, ')'), 4326)) AS is_within")
+      ->where("g.id = #geometry_id", ['geometry_id' => $geometryId])
+      ->where("ca.id = #address_id", ['address_id' => $addressId]);
+    $result = CRM_Core_DAO::executeQuery($select->toSQL())->fetchAll();
+
+
+    $result = CRM_Core_DAO::singleValueQuery("
+      SELECT ST_Contains(g.geometry, ST_GeomFromText(CONCAT('POINT(', ca.geo_code_2, ' ', ca.geo_code_1, ')'), 4326))
+      FROM civicrm_address ca, $geomTableName g
+      WHERE g.id = %1 AND ca.id = %2
+    ", [
+      1 => [$geometryId, 'Integer'],
+      2 => [$addressId, 'Integer'],
+    ]);
+
+    return boolval($result);
+  }
+
+  /**
+   * Get an Iterator that provides the address ids that are contained by a specific geometry_id.
+   *
+   * Uses the geometry bounds to generate a list of candidates before doing a more detailed
+   * ST_Contains confirmation.
+   *
+   * By default if a civicrm_address already has an entry in civigeometry_geometry_entity against
+   * the specified geometry, it will be skipped over. This is controlled by the
+   * precheck_relationships key in $params.
+   *
+   * @param  integer $geometry_id
+   *   The id of the geometry
+   *
+   * @param  array  $params
+   *   - batch_size: Integer. Default 100
+   *   - keep_temp_table: Boolean. Default false.
+   *   - precheck_relationships: Boolean. Default true.
+   *
+   * @return Iterator
+   *         Each item retrieved from the iterator will be an array of [geometry_id => integer,
+   *         address_id => integer]
+   */
+  function getAddresses($geometry_id, $params = []) {
+    $defaultParams = [
+      'batch_size' => 100,
+      'keep_temp_table' => false,
+      'precheck_relationships' => true,
+    ];
+    $params = $params + $defaultParams;
+
+    // Step 1. Find all the candidate addresses within the bounds of the geometry Use a table to
+    // store a potentially very large number of addresses
+    $bounds = civicrm_api3('Geometry', 'getbounds', ['id' => $geometry_id])['values'][$geometry_id];
+    $tmpTbl = CRM_Utils_SQL_TempTable::build();
+    if ($params['keep_temp_table']) {
+      $tmpTbl->setDurable();
     }
     else {
-      return [];
+      $tmpTbl->setAutodrop(true);
+    }
+    $tmpTbl->createWithColumns('address_id INT');
+
+    $tempTableName = $tmpTbl->getName();
+    if ($params['precheck_relationships']) {
+      CRM_Core_DAO::executeQuery("
+        INSERT INTO $tempTableName (address_id)
+        SELECT ca.id
+        FROM
+          civicrm_address ca
+        WHERE
+              ca.geo_code_2 >= %1
+          AND ca.geo_code_2 <= %2
+          AND ca.geo_code_1 <= %3
+          AND ca.geo_code_1 >= %4
+          AND NOT EXISTS (
+            SELECT *
+            FROM civigeometry_geometry_entity cge
+            WHERE
+              cge.entity_id = ca.id
+              AND cge.geometry_id = %5
+              AND cge.entity_table = 'civicrm_address'
+          )
+        ORDER BY ca.id
+      ", [
+        1 => [$bounds['left_bound'], 'Float'],
+        2 => [$bounds['right_bound'], 'Float'],
+        3 => [$bounds['top_bound'], 'Float'],
+        4 => [$bounds['bottom_bound'], 'Float'],
+        5 => [$geometry_id, 'Integer']
+      ]);
+    }
+    else {
+      CRM_Core_DAO::executeQuery("
+        INSERT INTO $tempTableName (address_id)
+        SELECT ca.id
+        FROM civicrm_address ca
+        WHERE
+              ca.geo_code_2 >= %1
+          AND ca.geo_code_2 <= %2
+          AND ca.geo_code_1 <= %3
+          AND ca.geo_code_1 >= %4
+        ORDER BY ca.id
+      ", [
+        1 => [$bounds['left_bound'], 'Float'],
+        2 => [$bounds['right_bound'], 'Float'],
+        3 => [$bounds['top_bound'], 'Float'],
+        4 => [$bounds['bottom_bound'], 'Float'],
+      ]);
+    }
+
+    $numCandidates = CRM_Core_DAO::singleValueQuery("SELECT COUNT(*) FROM $tempTableName");
+
+    $numBatches = ceil($numCandidates / $params['batch_size']);
+    $offset = 0;
+    for ($batchN=1; $batchN <= $numBatches; $batchN++) {
+      $candidates = self::getAddressesFetchCandidateBatch($tempTableName, $offset, $params['batch_size']);
+
+      if (count($candidates)) {
+        foreach ($candidates as $candidate) {
+          if (self::getAddressesGeometryContainsCandidate($geometry_id, $candidate['address_id'])) {
+            yield ['geometry_id' => $geometry_id, 'address_id' => $candidate['address_id']];
+          }
+        }
+
+        $offset += $params['batch_size'];
+      }
+      else {
+        throw new CRM_Core_ExecptionException(E::ts("No candidate addresses, but batches still remaining to process. That doesn't make any sense."));
+      }
     }
   }
 

--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -593,7 +593,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
         $offset += $params['batch_size'];
       }
       else {
-        throw new CRM_Core_ExecptionException(E::ts("No candidate addresses, but batches still remaining to process. That doesn't make any sense."));
+        throw new CRM_Core_Exception(E::ts("No candidate addresses, but batches still remaining to process. That doesn't make any sense."));
       }
     }
   }

--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -436,26 +436,26 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
   /**
    * Helper method for getAddresses. Fetches set of address_id values from $candidateTable
    *
-   * @param  string  $candidateTable The name of the table holding the candidate ids
+   * @param  string $candidateTable The name of the table holding the candidate ids
    * @param  integer $offset        Current offset
    * @param  integer $batchSize     The batch size
    * @return array                  The next batch of civicrm_address ids
    */
   public static function getAddressesFetchCandidateBatch($candidateTable, $offset, $batchSize) {
     $dao = CRM_Core_DAO::executeQuery("
-        SELECT ct.address_id
-        FROM $candidateTable ct
-        ORDER BY address_id
-        LIMIT %1
-        OFFSET %2
-      ", [
-        1 => [$batchSize, 'Integer'],
-        2 => [$offset, 'Integer'],
-      ]);
+      SELECT ct.address_id
+      FROM $candidateTable ct
+      ORDER BY address_id
+      LIMIT %1
+      OFFSET %2
+    ", [
+      1 => [$batchSize, 'Integer'],
+      2 => [$offset, 'Integer'],
+    ]);
 
-      $results = $dao->fetchAll();
+    $results = $dao->fetchAll();
 
-      return $results;
+    return $results;
   }
 
   /**
@@ -472,7 +472,6 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
       ->where("g.id = #geometry_id", ['geometry_id' => $geometryId])
       ->where("ca.id = #address_id", ['address_id' => $addressId]);
     $result = CRM_Core_DAO::executeQuery($select->toSQL())->fetchAll();
-
 
     $result = CRM_Core_DAO::singleValueQuery("
       SELECT ST_Contains(g.geometry, ST_GeomFromText(CONCAT('POINT(', ca.geo_code_2, ' ', ca.geo_code_1, ')'), 4326))
@@ -499,20 +498,16 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
    * @param  integer $geometry_id
    *   The id of the geometry
    *
-   * @param  array  $params
+   * @param  array $params
    *   - batch_size: Integer. Default 100
-   *   - keep_temp_table: Boolean. Default false.
-   *   - precheck_relationships: Boolean. Default true.
-   *
-   * @return Iterator
-   *         Each item retrieved from the iterator will be an array of [geometry_id => integer,
-   *         address_id => integer]
+   *   - keep_temp_table: Boolean. Default FALSE.
+   *   - precheck_relationships: Boolean. Default TRUE.
    */
-  function getAddresses($geometry_id, $params = []) {
+  private function getAddresses($geometry_id, $params = []) {
     $defaultParams = [
       'batch_size' => 100,
-      'keep_temp_table' => false,
-      'precheck_relationships' => true,
+      'keep_temp_table' => FALSE,
+      'precheck_relationships' => TRUE,
     ];
     $params = $params + $defaultParams;
 
@@ -524,7 +519,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
       $tmpTbl->setDurable();
     }
     else {
-      $tmpTbl->setAutodrop(true);
+      $tmpTbl->setAutodrop(TRUE);
     }
     $tmpTbl->createWithColumns('address_id INT');
 
@@ -554,7 +549,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
         2 => [$bounds['right_bound'], 'Float'],
         3 => [$bounds['top_bound'], 'Float'],
         4 => [$bounds['bottom_bound'], 'Float'],
-        5 => [$geometry_id, 'Integer']
+        5 => [$geometry_id, 'Integer'],
       ]);
     }
     else {
@@ -580,7 +575,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
 
     $numBatches = ceil($numCandidates / $params['batch_size']);
     $offset = 0;
-    for ($batchN=1; $batchN <= $numBatches; $batchN++) {
+    for ($batchN = 1; $batchN <= $numBatches; $batchN++) {
       $candidates = self::getAddressesFetchCandidateBatch($tempTableName, $offset, $params['batch_size']);
 
       if (count($candidates)) {

--- a/CRM/CiviGeometry/Tasks.php
+++ b/CRM/CiviGeometry/Tasks.php
@@ -48,8 +48,7 @@ class CRM_CiviGeometry_Tasks {
    * Get all the Addresses for this geometry
    */
   public static function buildGeometryRelationships(CRM_Queue_TaskContext $ctx, $geometry_id) {
-    $matches = CRM_CiviGeometry_BAO_Geometry::getAddresses($geometry_id);
-    foreach ($matches as $match) {
+    foreach (CRM_CiviGeometry_BAO_Geometry::getAddresses($geometry_id) as $match) {
       civicrm_api3('Address', 'creategeometries', [
         'geometry_id' => $match['geometry_id'],
         'address_id' => $match['address_id'],

--- a/api/v3/Address/Creategeometries.php
+++ b/api/v3/Address/Creategeometries.php
@@ -27,7 +27,7 @@ function _civicrm_api3_address_creategeometries_spec(&$spec) {
 }
 
 /**
- * Address.Getgeometries API
+ * Address.creategeometries API
  *
  * @param array $params
  * @return array API result descriptor

--- a/api/v3/Address/Getgeometries.php
+++ b/api/v3/Address/Getgeometries.php
@@ -62,7 +62,8 @@ function civicrm_api3_address_getgeometries($params) {
       return civicrm_api3_create_success(0);
     }
     else {
-      return civicrm_api3_create_success(CRM_CiviGeometry_BAO_Geometry::getAddresses($params['geometry_id']), $params);
+      $results = CRM_CiviGeometry_BAO_Geometry::getAddresses($params['geometry_id']);
+      return civicrm_api3_create_success(iterator_to_array($results), $params);
     }
   }
   $params['entity_table'] = 'civicrm_address';

--- a/civigeometry.php
+++ b/civigeometry.php
@@ -175,8 +175,12 @@ function civigeometry_civicrm_alterAPIPermissions($entity, $action, &$params, &$
 /**
  * Implements hook_civicrm_post().
  *
- * This adds records to civigeometry_adddress_geometry whenever an address is updated or created
- * also removes any records from the civigeomety_address_geometry table if the geometry gets archived.
+ * This adds records to civigeometry_address_geometry when:
+ * 1. Whenever an address is updated or created
+ * 2. Whenever a geometry is created
+ *
+ * Removes any records from the civigeomety_address_geometry table when:
+ * 1. A geometry gets archived.
  */
 function civigeometry_symfony_civicrm_post($event) {
   $hookValues = $event->getHookValues();

--- a/tests/phpunit/api/v3/GeometryTest.php
+++ b/tests/phpunit/api/v3/GeometryTest.php
@@ -971,7 +971,7 @@ class api_v3_GeometryTest extends \PHPUnit\Framework\TestCase implements Headles
     foreach ($addressesWithin as $addrId => $address) {
       $addressInGeom = false;
 
-      $hasKey = $this->assertArrayHasKey($addrId, $relationshipsA, "Address '" . $addressesWithin[$addrId]['street_address'] . "' should be within geometry. \$relationshipsA: " . print_r( $relationshipsA['values'], true));
+      $hasKey = $this->assertArrayHasKey($addrId, $relationshipsA, "Address '" . $addressesWithin[$addrId]['street_address'] . "' should be within geometry. \$relationshipsA: " . print_r($relationshipsA, true));
       if ($hasKey) {
         // Has correct geometry
         $this->assertEquals($upperHouseDistrict['id'], $relationshipsA[$addrId]['geometry_id']);
@@ -992,7 +992,7 @@ class api_v3_GeometryTest extends \PHPUnit\Framework\TestCase implements Headles
 
       $relationshipsB = array_column($geometryGetEntityResult['values'], null, 'entity_id');
 
-      $hasKey = $this->assertArrayHasKey($addrId, $relationshipsB, "Address '" . $addressesWithin[$addrId]['street_address'] . "' should be within geometry. \$relationshipsB: " . print_r( $relationshipsB['values'], true));
+      $hasKey = $this->assertArrayHasKey($addrId, $relationshipsB, "Address '" . $addressesWithin[$addrId]['street_address'] . "' should be within geometry. \$relationshipsB: " . print_r($relationshipsB, true));
       if ($hasKey) {
         $this->assertEquals($upperHouseDistrict['id'], $relationshipsB[$addrId]['geometry_id']);
       }

--- a/tests/phpunit/api/v3/GeometryTest.php
+++ b/tests/phpunit/api/v3/GeometryTest.php
@@ -752,7 +752,7 @@ class api_v3_GeometryTest extends \PHPUnit\Framework\TestCase implements Headles
     $this->assertEquals($geometry['id'], $geometryGet['values'][$geometry['id']]['id']);
     $this->assertEquals($this->sa1GeometryType['id'], $geometryGet['values'][$geometry['id']]['geometry_type_id']);
     // Assert that we haven't returned geometry.
-    $this->assertTRUE(!isset($geometryGet['values'][$geometry['id']]['geometry']));
+    $this->assertTrue(!isset($geometryGet['values'][$geometry['id']]['geometry']));
     // Assert that when we request geometry we get it back
     $geometryGet2 = $this->callAPISuccess('Geometry', 'get', ['id' => $geometry['id'], 'return' => ['geometry']]);
     $this->assertEquals(json_decode($geometryJSON, TRUE), json_decode($geometryGet2['values'][$geometry['id']]['geometry'], TRUE));
@@ -965,13 +965,13 @@ class api_v3_GeometryTest extends \PHPUnit\Framework\TestCase implements Headles
     $this->assertNotEmpty($addressApiGetGeometriesResult['values']);
 
     // Re-index to use entity_id as the key
-    $relationshipsA = array_column($addressApiGetGeometriesResult['values'], null, 'entity_id');
+    $relationshipsA = array_column($addressApiGetGeometriesResult['values'], NULL, 'entity_id');
 
     // Test that it found every address that was within
     foreach ($addressesWithin as $addrId => $address) {
-      $addressInGeom = false;
+      $addressInGeom = FALSE;
 
-      $hasKey = $this->assertArrayHasKey($addrId, $relationshipsA, "Address '" . $addressesWithin[$addrId]['street_address'] . "' should be within geometry. \$relationshipsA: " . print_r($relationshipsA, true));
+      $hasKey = $this->assertArrayHasKey($addrId, $relationshipsA, "Address '" . $addressesWithin[$addrId]['street_address'] . "' should be within geometry. \$relationshipsA: " . print_r($relationshipsA, TRUE));
       if ($hasKey) {
         // Has correct geometry
         $this->assertEquals($upperHouseDistrict['id'], $relationshipsA[$addrId]['geometry_id']);
@@ -990,9 +990,9 @@ class api_v3_GeometryTest extends \PHPUnit\Framework\TestCase implements Headles
         'entity_table' => 'civicrm_address',
       ]);
 
-      $relationshipsB = array_column($geometryGetEntityResult['values'], null, 'entity_id');
+      $relationshipsB = array_column($geometryGetEntityResult['values'], NULL, 'entity_id');
 
-      $hasKey = $this->assertArrayHasKey($addrId, $relationshipsB, "Address '" . $addressesWithin[$addrId]['street_address'] . "' should be within geometry. \$relationshipsB: " . print_r($relationshipsB, true));
+      $hasKey = $this->assertArrayHasKey($addrId, $relationshipsB, "Address '" . $addressesWithin[$addrId]['street_address'] . "' should be within geometry. \$relationshipsB: " . print_r($relationshipsB, TRUE));
       if ($hasKey) {
         $this->assertEquals($upperHouseDistrict['id'], $relationshipsB[$addrId]['geometry_id']);
       }
@@ -1005,7 +1005,7 @@ class api_v3_GeometryTest extends \PHPUnit\Framework\TestCase implements Headles
         'entity_table' => 'civicrm_address',
       ]);
 
-      $relationshipsC = array_column($geometryGetEntityResult['values'], null, 'entity_id');
+      $relationshipsC = array_column($geometryGetEntityResult['values'], NULL, 'entity_id');
 
       $this->assertArrayNotHasKey($addrId, $relationshipsC, "Address '" . $addressesNotWithin[$addrId]['street_address'] . "' should not be within geometry.");
     }

--- a/tests/phpunit/api/v3/GeometryTest.php
+++ b/tests/phpunit/api/v3/GeometryTest.php
@@ -926,7 +926,7 @@ class api_v3_GeometryTest extends \PHPUnit\Framework\TestCase implements Headles
 
     // Create a CiviCRM Addresses with a known points
     $addressesJSON = file_get_contents(\CRM_Utils_File::addTrailingSlash($this->jsonDirectoryStore) . 'tasmanian_upper_house_geometry_addresses.geojson');
-    $addressesCollection = json_decode($addressesJSON, true);
+    $addressesCollection = json_decode($addressesJSON, TRUE);
     $addressFeatures = $addressesCollection['features'];
 
     $addressesWithin = [];
@@ -943,8 +943,12 @@ class api_v3_GeometryTest extends \PHPUnit\Framework\TestCase implements Headles
         'geo_code_2' => $addressFeature['geometry']['coordinates'][0],
       ]);
 
-      if ($addressFeature['properties']['within']) $addressesWithin[$address['id']] = $address;
-      else $addressesNotWithin[$address['id']] = $address;
+      if ($addressFeature['properties']['within']) {
+        $addressesWithin[$address['id']] = $address;
+      }
+      else {
+        $addressesNotWithin[$address['id']] = $address;
+      }
     }
 
     // Process The Geometry Queue.

--- a/tests/phpunit/api/v3/GeometryTest.php
+++ b/tests/phpunit/api/v3/GeometryTest.php
@@ -970,8 +970,8 @@ class api_v3_GeometryTest extends \PHPUnit\Framework\TestCase implements Headles
     }
 
     // Test that it it did NOT find any of the addresses not within
-    foreach ($addressesNotWithin as $id => $address) {
-      $this->assertArrayNotHasKey($id, $addressApiGetGeometriesResult['values'], "Address '" . $addressesNotWithin[$id]['street_address'] . "' should not be within geometry.");
+    foreach ($addressesNotWithin as $addrId => $address) {
+      $this->assertArrayNotHasKey($addrId, $addressApiGetGeometriesResult['values'], "Address '" . $addressesNotWithin[$addrId]['street_address'] . "' should not be within geometry.");
     }
 
     // Return geometry,address entity relationships for each address via the Geometry api
@@ -987,6 +987,16 @@ class api_v3_GeometryTest extends \PHPUnit\Framework\TestCase implements Headles
       if ($hasKey) {
         $this->assertEquals($upperHouseDistrict['id'], $geometryGetEntityResult['values'][$addrId]['geometry_id']);
       }
+    }
+
+    // Test that it it did NOT find any of the addresses not within
+    foreach ($addressesNotWithin as $addrId => $address) {
+      $geometryGetEntityResult = $this->callAPISuccess('geometry', 'getentity', [
+        'entity_id' => $addrId,
+        'entity_table' => 'civicrm_address',
+      ]);
+
+      $this->assertArrayNotHasKey($addrId, $geometryGetEntityResult['values'], "Address '" . $addressesNotWithin[$addrId]['street_address'] . "' should not be within geometry.");
     }
 
     $this->callAPISuccess('Address', 'delete', ['id' => $address['id']]);

--- a/tests/phpunit/api/v3/GeometryTest.php
+++ b/tests/phpunit/api/v3/GeometryTest.php
@@ -963,7 +963,7 @@ class api_v3_GeometryTest extends \PHPUnit\Framework\TestCase implements Headles
 
     // Test that it found every address that was within
     foreach ($addressesWithin as $addrId => $address) {
-      $hasKey = $this->assertArrayHaskey($addrId, $addressApiGetGeometriesResult['values'], "Address '" . $addressesWithin[$addrId]['street_address'] . "' should be within geometry.");
+      $hasKey = $this->assertArrayHaskey($addrId, $addressApiGetGeometriesResult['values'], "Address '" . $addressesWithin[$addrId]['street_address'] . "' should be within geometry. \$addressApiGetGeometriesResult: " . print_r( $addressApiGetGeometriesResult['values'], true));
       if ($hasKey) {
         // Has correct geometry
         $this->assertEquals($upperHouseDistrict['id'], $addressApiGetGeometriesResult['values'][$addrId]['geometry_id']);
@@ -984,7 +984,7 @@ class api_v3_GeometryTest extends \PHPUnit\Framework\TestCase implements Headles
         'entity_table' => 'civicrm_address',
       ]);
 
-      $hasKey = $this->assertArrayHaskey($addrId, $geometryGetEntityResult['values'], "Address '" . $addressesWithin[$addrId]['street_address'] . "' should be within geometry.");
+      $hasKey = $this->assertArrayHaskey($addrId, $geometryGetEntityResult['values'], "Address '" . $addressesWithin[$addrId]['street_address'] . "' should be within geometry. \$geometryGetEntityResult: " . print_r( $geometryGetEntityResult['values'], true));
       if ($hasKey) {
         $this->assertEquals($upperHouseDistrict['id'], $geometryGetEntityResult['values'][$addrId]['geometry_id']);
       }

--- a/tests/phpunit/api/v3/GeometryTest.php
+++ b/tests/phpunit/api/v3/GeometryTest.php
@@ -959,6 +959,7 @@ class api_v3_GeometryTest extends \PHPUnit\Framework\TestCase implements Headles
     // Return the geometry,address entity relationships for geometry via Address api
     $addressApiGetGeometriesResult = $this->callAPISuccess('Address', 'getgeometries', ['geometry_id' => $upperHouseDistrict['id']]);
 
+    $this->assertNotEmpty($addressApiGetGeometriesResult['values']);
 
     // Test that it found every address that was within
     foreach ($addressesWithin as $addrId => $address) {

--- a/tests/phpunit/api/v3/load/tasmanian_upper_house_geometry_addresses.geojson
+++ b/tests/phpunit/api/v3/load/tasmanian_upper_house_geometry_addresses.geojson
@@ -1,0 +1,167 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "within": true,
+        "street_address": "120 Within St",
+        "city": "Springfield",
+        "marker-color": "#00ff00",
+        "marker-size": "medium",
+        "marker-symbol": ""
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          147.25301742553708,
+          -42.984903469297315
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "within": true,
+        "street_address": "121 Within St",
+        "city": "Springfield",
+        "marker-color": "#00ff00",
+        "marker-size": "medium",
+        "marker-symbol": ""
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          147.33318328857422,
+          -42.894925286977134
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "within": true,
+        "street_address": "122 Within St",
+        "city": "Springfield",
+        "marker-color": "#00ff00",
+        "marker-size": "medium",
+        "marker-symbol": ""
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          147.19542503356934,
+          -42.98229771153605
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "within": true,
+        "street_address": "123 Within St",
+        "city": "Springfield",
+        "marker-color": "#00ff00",
+        "marker-size": "medium",
+        "marker-symbol": ""
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          147.32666015624997,
+          -42.98870202671632
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "within": true,
+        "street_address": "125 Within St",
+        "city": "Springfield",
+        "marker-color": "#00ff00",
+        "marker-size": "medium",
+        "marker-symbol": ""
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          147.30125427246094,
+          -42.94436044696629
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "within": false,
+        "street_address": "1 Outside St",
+        "city": "Shelbyville",
+        "marker-color": "#ff0000",
+        "marker-size": "medium",
+        "marker-symbol": "cross"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          147.2450888156891,
+          -42.96879623439108
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "within": false,
+        "street_address": "2 Outside St",
+        "city": "Shelbyville",
+        "marker-color": "#ff0000",
+        "marker-size": "medium",
+        "marker-symbol": "cross"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          147.28958129882812,
+          -42.98945543169632
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "within": false,
+        "street_address": "3 Outside St",
+        "city": "Shelbyville",
+        "marker-color": "#ff0000",
+        "marker-size": "medium",
+        "marker-symbol": "cross"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          147.2519874572754,
+          -42.91551499483697
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "within": false,
+        "street_address": "4 Outside St",
+        "city": "Shelbyville",
+        "marker-color": "#ff0000",
+        "marker-size": "medium",
+        "marker-symbol": "cross"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          147.34966278076172,
+          -42.95692504577837
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This is a complete refactor of CRM_CiviGeometry_BAO_Geometry->getAddresses(), converting it into a generator function.
The iterator that is returned is same as each element of the previously returned array, so only required minor changes to CRM_CiviGeometry_Tasks::buildGeometryRelationships()

Basic method:

1. Uses a temp table to built up a list of potential candidates that are within the bounds of the geometry (rather than storing results in an array).
2. By default will eliminate civicrm_address entities that already have a relationship with the geometry in civigeometry_geometry_entity table. This can be modified with $params['precheck_relationships']
3. Fetches from these in batches of 100 (adjustable with $params['batch_size']), doing the full ST_Contains check on each as before.