### PR TITLE
Workaround MariaDB spatial index / lock bug (MDEV-26123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes for the CiviGeometry extension will be noted here.
 ## [1.8.2] - 2021-10-18
 ### Changed
  - wrap queries involving spatial functions in transactions. Added in response to
-   a critical bug in MariaDB 10.4.X involving spatial indexes and table locking
+   a critical bug in MariaDB 10.4.X involving spatial indexes and table locking.
+   cf. https://jira.mariadb.org/browse/MDEV-26123
 
 ## [1.8.1] - 2021-10-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes for the CiviGeometry extension will be noted here.
 
+## [1.8.2] - 2021-10-18
+### Changed
+ - wrap queries involving spatial functions in transactions. Added in response to
+   a critical bug in MariaDB 10.4.X involving spatial indexes and table locking
+
 ## [1.8.1] - 2021-10-06
 ### Fixed
  - Reordered field order for composite indexes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes for the CiviGeometry extension will be noted here.
 
 ## [1.8.2] - 2021-10-18
 ### Changed
- - wrap queries involving spatial functions in transactions. Added in response to
-   a critical bug in MariaDB 10.4.X involving spatial indexes and table locking.
+ - Modified SELECT queries involving spatial data to end with 'FOR UPDATE'. Added
+   in response to a critical bug in MariaDB (across several versions) involving
+   spatial indexes and table locking.
    cf. https://jira.mariadb.org/browse/MDEV-26123
 
 ## [1.8.1] - 2021-10-06

--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -518,7 +518,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
       ->select("ST_Contains(g.geometry, ST_GeomFromText(CONCAT('POINT(', ca.geo_code_2, ' ', ca.geo_code_1, ')'), 4326)) AS is_within")
       ->where("g.id = #geometry_id", ['geometry_id' => $geometryId])
       ->where("ca.id = #address_id", ['address_id' => $addressId]);
-    CRM_Core_Transaction::create()->run(function($tx) {CRM_Core_Transaction::create()->run(function($tx) {
+    CRM_Core_Transaction::create()->run(function($tx) {
       $result = CRM_Core_DAO::executeQuery($select->toSQL())->fetchAll();
       $result = CRM_Core_DAO::singleValueQuery("
         SELECT ST_Contains(g.geometry, ST_GeomFromText(CONCAT('POINT(', ca.geo_code_2, ' ', ca.geo_code_1, ')'), 4326))

--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -171,7 +171,9 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
       }
     }
 
-    $res = CRM_Core_DAO::executeQuery("SELECT $selectStr FROM $fromStr WHERE $whereStr", $queryParams);
+    CRM_Core_Transaction::create()->run(function($tx) {
+      $res = CRM_Core_DAO::executeQuery("SELECT $selectStr FROM $fromStr WHERE $whereStr", $queryParams);
+    });
 
     return array_column($res->fetchAll(), 'id');
   }

--- a/info.xml
+++ b/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-10-06</releaseDate>
-  <version>1.8.1</version>
+  <version>1.8.2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.13</ver>


### PR DESCRIPTION
This PR modifies all queries involving spatial data/indexes in the extension to use the `SELECT...FOR UPDATE` pattern. This pattern is used to workaround the MariaDB bug [documented in MDEV-26123](https://jira.mariadb.org/browse/MDEV-26123).

The preferred approach would be to preceed the `CRM_Core_DAO::executeQuery` calls with `$tx = new CRM_Core_Transaction` or similar. Unfortunately this approach has not worked as expected.

The use of `FOR UPDATE` has been tested locally via the updated code and "by hand". It works as expected in both cases.