### PR TITLE
Fix several issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes for the CiviGeometry extension will be noted here.
 
+## [1.8.3] - 2021-10-18
+### Changed
+ - Made tests phpunit8 compatible
+
+### Fixed
+ - Declare functions statically
+ - Removed redundant DB query
+
 ## [1.8.2] - 2021-10-18
 ### Changed
  - Modified SELECT queries involving spatial data to end with 'FOR UPDATE'. Added
@@ -33,8 +41,6 @@ All notable changes for the CiviGeometry extension will be noted here.
    performant.
 
 ## [1.5.2] - 2020-09-29
-### Added
-
 ### Changed
  - Removed overlap cache expiry of 1 month. Overlaps should only expire when the geometries change
 

--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -503,11 +503,6 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
    */
   protected static function getAddressesGeometryContainsCandidate($geometryId, $addressId) {
     $geomTableName = self::getTableName();
-    $select = CRM_Utils_SQL_Select::from($geomTableName . ' g, civicrm_address ca')
-      ->select("ST_Contains(g.geometry, ST_GeomFromText(CONCAT('POINT(', ca.geo_code_2, ' ', ca.geo_code_1, ')'), 4326)) AS is_within FOR UPDATE")
-      ->where("g.id = #geometry_id", ['geometry_id' => $geometryId])
-      ->where("ca.id = #address_id", ['address_id' => $addressId]);
-    $result = CRM_Core_DAO::executeQuery($select->toSQL())->fetchAll();
     $result = CRM_Core_DAO::singleValueQuery("
       SELECT ST_Contains(g.geometry, ST_GeomFromText(CONCAT('POINT(', ca.geo_code_2, ' ', ca.geo_code_1, ')'), 4326))
       FROM civicrm_address ca, $geomTableName g

--- a/info.xml
+++ b/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-10-06</releaseDate>
-  <version>1.8.2</version>
+  <version>1.8.3</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.13</ver>


### PR DESCRIPTION
Fixes some issues discovered today:
- phpunit test issues (notably phpunit8 compatibility)
- DB query syntax errors (bad placement of `FOR UPDATE`)
- redundant code in `getAddressesGeometryContainsCandidate` function

The most notable change is the last one. The DB query constructed lines 505-509 was throwing syntax errors given the poor placement of the `FOR UPDATE`. While working on that I realised the entire query is redundant; it's replicated immediately below (note the `$result` variable gets immediately overwritten.
