### PR TITLE
Feature: Geometry.getcachedoverlaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes for the CiviGeometry extension will be noted here.
 
+## [1.9.0] - 2022-08-26
+### Added
+ - Geometry.getcachedoverlaps method to retrieve all geometries that overlap with input geometry
 ## [1.8.7] - 2022-08-24
 ### Changed
  - Added 'access AJAX API' permission to defaults for API entity get methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes for the CiviGeometry extension will be noted here.
 
+## [1.8.7] - 2022-08-24
+### Changed
+ - Added 'access AJAX API' permission to defaults for API entity get methods
+
 ## [1.8.6] - 2022-04-20
 ### Changed
  - Changed CiviCRM Queue implementation from Sql to SqlParallel

--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -314,15 +314,15 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
     }
     $geometry_id_filter = \CRM_Core_DAO::createSQLFilter('geometry_id_b', $params['geometry_id']);
     $overlap = isset($params['overlap']) ? $params['overlap'] : 0;
-    $inner_geometries = CRM_Core_DAO::executeQuery("
+    $overlapping_geometries = CRM_Core_DAO::executeQuery("
       SELECT id, geometry_id_a AS geometry_id, overlap
       FROM civigeometry_geometry_overlap_cache
       WHERE $geometry_id_filter AND overlap >= %1", [
         1 => [$overlap, 'Positive'],
       ]); 
     $results = [];
-    while ($inner_geometries->fetch()) {
-      $results[$inner_geometries->id] = $inner_geometries->geometry_id;
+    while ($overlapping_geometries->fetch()) {
+      $results[$overlapping_geometries->id] = $overlapping_geometries->geometry_id;
     }
     return $results;
   }

--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -303,15 +303,15 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
   }
 
   /**
-   * Get all overlapping geometries
+   * Get all cached overlapping geometries
    * @param array $params
    * @return array|bool
    */
-  public static function getAllOverlappingGeometries($params) {
+  public static function getCachedOverlappingGeometries($params) {
     $outer_geometry= $params['geometry_id'];
-    $overlap = isset($params['overlap']) ? $params['overlap'] : 50;
+    $overlap = isset($params['overlap']) ? $params['overlap'] : 0;
     $inner_geometries = CRM_Core_DAO::executeQuery("
-      SELECT geometry_id_a AS geometry, overlap
+      SELECT geometry_id_a AS geometry_id, overlap
       FROM civigeometry_geometry_overlap_cache
       WHERE geometry_id_b = %1 AND overlap >= %2", [
         1 => [$outer_geometry, 'Positive'],

--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -303,6 +303,28 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
   }
 
   /**
+   * Get all overlapping geometries
+   * @param array $params
+   * @return array|bool
+   */
+  public static function getAllOverlappingGeometries($params) {
+    $outer_geometry= $params['geometry_id'];
+    $overlap = isset($params['overlap']) ? $params['overlap'] : 50;
+    $inner_geometries = CRM_Core_DAO::executeQuery("
+      SELECT geometry_id_a AS geometry, overlap
+      FROM civigeometry_geometry_overlap_cache
+      WHERE geometry_id_b = %1 AND overlap >= %2", [
+        1 => [$outer_geometry, 'Positive'],
+        2 => [$overlap, 'Positive'],
+      ]); 
+    $results = [];
+    while ($inner_geometries->fetch()) {
+      $results[] = $inner_geometries->geometry;
+    }
+    return $results;
+  }
+
+  /**
    * Calculate Overlap between two geometries
    * @param array $params
    * @return array|bool

--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -319,7 +319,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
       FROM civigeometry_geometry_overlap_cache
       WHERE $geometry_id_filter AND overlap >= %1", [
         1 => [$overlap, 'Positive'],
-      ]); 
+      ]);
     $results = [];
     while ($overlapping_geometries->fetch()) {
       $results[$overlapping_geometries->id] = $overlapping_geometries->geometry_id;

--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -311,7 +311,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
     $outer_geometry= $params['geometry_id'];
     $overlap = isset($params['overlap']) ? $params['overlap'] : 0;
     $inner_geometries = CRM_Core_DAO::executeQuery("
-      SELECT geometry_id_a AS geometry_id, overlap
+      SELECT id, geometry_id_a AS geometry_id, overlap
       FROM civigeometry_geometry_overlap_cache
       WHERE geometry_id_b = %1 AND overlap >= %2", [
         1 => [$outer_geometry, 'Positive'],
@@ -319,7 +319,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
       ]); 
     $results = [];
     while ($inner_geometries->fetch()) {
-      $results[] = $inner_geometries->geometry;
+      $results[$inner_geometries->id] = $inner_geometries->geometry_id;
     }
     return $results;
   }

--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -308,14 +308,17 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
    * @return array|bool
    */
   public static function getCachedOverlappingGeometries($params) {
-    $outer_geometry= $params['geometry_id'];
+    $operator = is_array($params['geometry_id']) ? \CRM_Utils_Array::first(array_keys($params['geometry_id'])) : NULL;
+    if (!in_array($operator, \CRM_Core_DAO::acceptedSQLOperators(), TRUE)) {
+      $params['geometry_id'] = ['=' => $params['geometry_id']];
+    }
+    $geometry_id_filter = \CRM_Core_DAO::createSQLFilter('geometry_id_b', $params['geometry_id']);
     $overlap = isset($params['overlap']) ? $params['overlap'] : 0;
     $inner_geometries = CRM_Core_DAO::executeQuery("
       SELECT id, geometry_id_a AS geometry_id, overlap
       FROM civigeometry_geometry_overlap_cache
-      WHERE geometry_id_b = %1 AND overlap >= %2", [
-        1 => [$outer_geometry, 'Positive'],
-        2 => [$overlap, 'Positive'],
+      WHERE $geometry_id_filter AND overlap >= %1", [
+        1 => [$overlap, 'Positive'],
       ]); 
     $results = [];
     while ($inner_geometries->fetch()) {

--- a/Civi/Api4/Action/Geometry/GetCachedOverlaps.php
+++ b/Civi/Api4/Action/Geometry/GetCachedOverlaps.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Civi\Api4\Action\Geometry;
+
+use Civi\Api4\Generic\Result;
+
+/**
+ * Get Overlaps between 2 Geometries.
+ * @method getGeometryIdA()
+ * @method setGeometryIdA($geometry_id)
+ * @method getOverlap()
+ * @method setOverlap(int $overlap)
+ */
+class GetCachedOverlaps extends \Civi\Api4\Generic\AbstractAction {
+
+  /**
+   * Geometry id a
+   *
+   * @var int
+   */
+  protected $geometry_id;
+
+  /**
+   * Minimum overlap required.
+   *
+   * @var int
+   */
+  protected $overlap;
+
+  public function _run(Result $result) {
+    $params = [
+      'geometry_id' => $this->geometry_id_a,
+      'overlap' => $this->overlap,
+    ];
+    return \CRM_CiviGeometry_BAO_Geometry::getCachedOverlappingGeometries($params);
+  }
+
+}

--- a/Civi/Api4/Action/Geometry/GetCachedOverlaps.php
+++ b/Civi/Api4/Action/Geometry/GetCachedOverlaps.php
@@ -32,7 +32,10 @@ class GetCachedOverlaps extends \Civi\Api4\Generic\AbstractAction {
       'geometry_id' => $this->geometry_id,
       'overlap' => $this->overlap,
     ];
-    return \CRM_CiviGeometry_BAO_Geometry::getCachedOverlappingGeometries($params);
+    $dbResult = \CRM_CiviGeometry_BAO_Geometry::getCachedOverlappingGeometries($params);
+    foreach ($dbResult as $res) {
+      $result[] = $res;
+    }
   }
 
 }

--- a/Civi/Api4/Action/Geometry/GetCachedOverlaps.php
+++ b/Civi/Api4/Action/Geometry/GetCachedOverlaps.php
@@ -6,8 +6,8 @@ use Civi\Api4\Generic\Result;
 
 /**
  * Get Overlaps between 2 Geometries.
- * @method getGeometryIdA()
- * @method setGeometryIdA($geometry_id)
+ * @method getGeometryId()
+ * @method setGeometryId($geometry_id)
  * @method getOverlap()
  * @method setOverlap(int $overlap)
  */
@@ -29,7 +29,7 @@ class GetCachedOverlaps extends \Civi\Api4\Generic\AbstractAction {
 
   public function _run(Result $result) {
     $params = [
-      'geometry_id' => $this->geometry_id_a,
+      'geometry_id' => $this->geometry_id,
       'overlap' => $this->overlap,
     ];
     return \CRM_CiviGeometry_BAO_Geometry::getCachedOverlappingGeometries($params);

--- a/Civi/Api4/Geometry.php
+++ b/Civi/Api4/Geometry.php
@@ -120,6 +120,15 @@ class Geometry extends Generic\DAOEntity {
 
   /**
    * @param bool $checkPermissions
+   * @return Action\Geometry\GetOverlap
+   */
+  public static function getcachedoverlaps($checkPermissions = TRUE) {
+    return (new Action\Geometry\GetCachedOverlaps(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
    * @return Action\Geometry\GetBounds
    */
   public static function getbounds($checkPermissions = TRUE) {
@@ -179,6 +188,14 @@ class Geometry extends Generic\DAOEntity {
   public static function getnearest($checkPermissions = TRUE) {
     return (new Action\Geometry\GetNearest(__CLASS__, __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
+  }
+
+  public static function permissions() {
+    return [
+      'default' => ['access geometry'],
+      'create' => [['administer geometry', 'administer civicrm']],
+      'delete' => [['administer geometry', 'administer civicrm']],
+    ];
   }
 
 }

--- a/Civi/Api4/GeometryCollection.php
+++ b/Civi/Api4/GeometryCollection.php
@@ -28,4 +28,14 @@ class GeometryCollection extends Generic\DAOEntity {
       ->setCheckPermissions($checkPermissions);
   }
 
+  public static function permissions() {
+    return [
+      'create' => [['administer geometry', 'administer civicrm']],
+      'archive' => [['administer geometry', 'administer civicrm']],
+      'unarchive' => [['administer geometry', 'administer civicrm']],
+      'delete' => [['administer geometry', 'administer civicrm']],
+      'default' => ['access geometry'],
+    ];
+  }
+
 }

--- a/Civi/Api4/GeometryCollectionType.php
+++ b/Civi/Api4/GeometryCollectionType.php
@@ -10,4 +10,12 @@ namespace Civi\Api4;
  */
 class GeometryCollectionType extends Generic\DAOEntity {
 
+  public static function permissions() {
+    return [
+      'create' => [['administer geometry', 'administer civicrm']],
+      'delete' => [['administer geometry', 'administer civicrm']],
+      'default' => ['access geometry'],
+    ];
+  }
+
 }

--- a/Civi/Api4/GeometryType.php
+++ b/Civi/Api4/GeometryType.php
@@ -10,4 +10,12 @@ namespace Civi\Api4;
  */
 class GeometryType extends Generic\DAOEntity {
 
+  public static function permissions() {
+    return [
+      'create' => [['administer geometry', 'administer civicrm']],
+      'delete' => [['administer geometry', 'administer civicrm']],
+      'default' => ['access geometry'],
+    ];
+  }
+
 }

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Avaliable Entities and methods
     - `getBounds` - Return the min/max X and Y points of a geometry
     - `getDistance` - Return the distance specified between two points. The points need to be specified in string format in the format of `POINT(x, y)`
     - `getOverlap` - Determine the overlap between two geometry shapes. Returned as a percentage
+    - `getCachedOverlaps` - Returna list of all geometries that overlap the supplied geometry (with optional minimum overlap percentage)
     - `runqueue` - Runs the queued up address placement and geometry - address relationship creation jobs stored in the Geometry extension queue. 
     - `getentity` - Get relationships between geometries and associated entities, must supply either a `geometry_id` or the combination of entity_id and entity_table. The purpose of the relationships is to assist where entities may need to have a definition that is based on geometry or similar. E.g. An electorate in Australia is defined by the geographical area it covers.
     - `createentity` - Create a relationship between a geometry and an enttiy, must supply an `entity_id`, `entity_table` = match to MySQL table name and a `geometry_id`.

--- a/api/v3/Geometry.php
+++ b/api/v3/Geometry.php
@@ -514,7 +514,7 @@ function _civicrm_api3_geometry_getintersection_spec(&$spec) {
 }
 
 /**
- * Geomety.getOverlap
+ * Geometry.getOverlap
  *
  * @param array $params
  * @return array API result descriptor
@@ -546,6 +546,38 @@ function _civicrm_api3_geometry_getoverlap_spec(&$spec) {
   $spec['geometry_id_b']['type'] = CRM_Utils_Type::T_INT;
   $spec['overlap']['title'] = E::ts('Minimum overlap');
   $spec['overlap']['type'] = CRM_Utils_Type::T_INT;
+}
+
+/**
+ * Geometry.getcachedoverlaps API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec description of fields supported by this API call
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_geometry_getcachedoverlaps_spec(&$spec) {
+  $spec['geometry_id']['title'] = E::ts('Geometry ID');
+  $spec['geometry_id']['api.required'] = 1;
+  $spec['geometry_id']['type'] = CRM_Utils_Type::T_INT;
+  $spec['overlap']['title'] = E::ts('Minimum overlap');
+  $spec['overlap']['type'] = CRM_Utils_Type::T_INT;
+}
+
+/**
+ * Geometry.getCachedOverlaps
+ *
+ * @param array $params
+ * @return array API result descriptor
+ * @throws API_Exception
+ */
+function civicrm_api3_geometry_getcachedoverlaps($params) {
+  $results = [];
+  $overlapGeometries = CRM_CiviGeometry_BAO_Geometry::getCachedOverlappingGeometries($params);
+  if (!empty($overlapGeometries)) {
+    $results = $overlapGeometries;
+  }
+  return $overlapGeometries;
 }
 
 /**

--- a/api/v3/Geometry.php
+++ b/api/v3/Geometry.php
@@ -577,7 +577,7 @@ function civicrm_api3_geometry_getcachedoverlaps($params) {
   if (!empty($overlapGeometries)) {
     $results = $overlapGeometries;
   }
-  return $overlapGeometries;
+  return civicrm_api3_create_success($overlapGeometries);
 }
 
 /**

--- a/civigeometry.php
+++ b/civigeometry.php
@@ -162,7 +162,7 @@ function civigeometry_civicrm_permission(&$permissions) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/
  */
 function civigeometry_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
-  $permissions['address']['geogeometries'] = [['access civicrm', 'access AJAX API']];
+  $permissions['address']['getgeometries'] = [['access civicrm', 'access AJAX API']];
   $permissions['geometry']['create'] = $permissions['geometry']['delete'] = [['administer geometry', 'administer civicrm']];
   $permissions['geometry']['default'] = array('access geometry');
   $permissions['geometry_collection']['create'] = [['administer geometry', 'administer civicrm']];

--- a/civigeometry.php
+++ b/civigeometry.php
@@ -162,13 +162,14 @@ function civigeometry_civicrm_permission(&$permissions) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/
  */
 function civigeometry_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
-  $permissions['geometry']['create'] = $permissions['geometry']['delete'] = array(array('administer geometry', 'administer civicrm'));
+  $permissions['address']['geogeometries'] = [['access civicrm', 'access AJAX API']];
+  $permissions['geometry']['create'] = $permissions['geometry']['delete'] = [['administer geometry', 'administer civicrm']];
   $permissions['geometry']['default'] = array('access geometry');
-  $permissions['geometry_collection']['create'] = array(array('administer geometry', 'administer civicrm'));
-  $permissions['geometry_collection']['default'] = array('access geometry');
+  $permissions['geometry_collection']['create'] = [['administer geometry', 'administer civicrm']];
+  $permissions['geometry_collection']['default'] = ['access geometry'];
   $permissions['geometry_collection']['unarchive'] = $permissions['geometry_collection']['archive'] = $permissions['geometry_collection']['delete'] = $permissions['geometry_collection']['create'];
-  $permissions['geometry_type']['create'] = $permissions['geometry_type']['delete'] = array(array('administer geometry', 'administer civicrm'));
-  $permissions['geometry_type']['default'] = array('access geometry');
+  $permissions['geometry_type']['create'] = $permissions['geometry_type']['delete'] = [['administer geometry', 'administer civicrm']];
+  $permissions['geometry_type']['default'] = ['access geometry'];
   $permissions['geometry_collection_type'] = $permissions['geometry_type'];
 }
 

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/australiangreens/au.org.greens.civigeometry</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2022-08-24</releaseDate>
-  <version>1.8.7</version>
+  <releaseDate>2022-08-25</releaseDate>
+  <version>1.9.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.13</ver>

--- a/info.xml
+++ b/info.xml
@@ -14,7 +14,7 @@
     <url desc="Support">https://github.com/australiangreens/au.org.greens.civigeometry</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2022-08-25</releaseDate>
+  <releaseDate>2022-08-26</releaseDate>
   <version>1.9.0</version>
   <develStage>stable</develStage>
   <compatibility>

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/australiangreens/au.org.greens.civigeometry</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2022-04-13</releaseDate>
-  <version>1.8.6</version>
+  <releaseDate>2022-08-24</releaseDate>
+  <version>1.8.7</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.13</ver>

--- a/tests/phpunit/api/v3/GeometryTest.php
+++ b/tests/phpunit/api/v3/GeometryTest.php
@@ -590,6 +590,9 @@ class api_v3_GeometryTest extends \PHPUnit\Framework\TestCase implements Headles
       'overlap' => 10,
     ]);
     $this->assertTrue(empty($cacheResutlMinOverlap['values']));
+    $getCachedOverlaps = $this->callAPISuccess('Geometry', 'getcachedoverlaps', ['geometry_id' => $queensland['id']]);
+    $cachedKey = key($getCachedOverlaps['values']);
+    $this->assertEquals($cairns['id'], $getCachedOverlaps['values'][$cachedKey]);
     $this->callAPISuccess('Geometry', 'delete', ['id' => $cairns['id']]);
     $this->callAPISuccess('Geometry', 'delete', ['id' => $queensland['id']]);
     $this->callAPISuccess('GeometryType', 'delete', ['id' => $wardGeometryType['id']]);


### PR DESCRIPTION
Adds a new `Geometry.getcachedoverlaps` method for retrieving a list of geomtry IDs that overlap with the supplied geometry. Supports an optional `overlap` parameter to specify the minimum percentage overlap that should be considered to retrieve the list.

Only queries the cached overlaps for performance reasons. Given cached overlap data is only invalidated when geometries are archived, this should be a "safe" decision.