### PR TITLE
Api4: Address.getgeometries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes for the CiviGeometry extension will be noted here.
 
+## [1.10.1] - 2023-07-19
+### Added
+ - Address.getgeometries APIv4 method
+### Changed
+ - Marked Address.getgeometries APIv3 method as deprecated
+### Fixed
+ - Bug in APIv3 call
+
 ## [1.9.0] - 2022-08-26
 ### Added
  - Geometry.getcachedoverlaps method to retrieve all geometries that overlap with input geometry

--- a/Civi/Api4/Action/Address/GetGeometries.php
+++ b/Civi/Api4/Action/Address/GetGeometries.php
@@ -52,7 +52,7 @@ class GetGeometries extends \Civi\Api4\Generic\AbstractAction {
       }
     }
     else {
-      $geometries = \Civi\Api4\Geometry:getEntity(FALSE)
+      $geometries = \Civi\Api4\Geometry::getEntity(FALSE)
         ->addSelect('geometry_id')
         ->addWhere('entity_table', '=', 'civicrm_address')
         ->addWhere('entity_id', '=', $this->address_id)

--- a/Civi/Api4/Action/Address/GetGeometries.php
+++ b/Civi/Api4/Action/Address/GetGeometries.php
@@ -18,12 +18,6 @@ class GetGeometries extends \Civi\Api4\Generic\AbstractAction {
   protected $address_id;
 
   /**
-   * Geometry Id
-   * @var int
-   */
-  protected $geometry_id;
-
-  /**
    * Skip cache
    * @var bool
    */

--- a/Civi/Api4/Action/Address/GetGeometries.php
+++ b/Civi/Api4/Action/Address/GetGeometries.php
@@ -59,7 +59,7 @@ class GetGeometries extends \Civi\Api4\Generic\AbstractAction {
         ->execute();
       while ($geometries->fetch()) {
         $result[] = [
-          'id' => $geometries=>id,
+          'id' => $geometries->id,
           'entity_id' => $geometries->entity_id,
           'entity_table' =>'civicrm_address',
           'geometry_id' => $geometries->geometry_id,

--- a/Civi/Api4/Action/Address/GetGeometries.php
+++ b/Civi/Api4/Action/Address/GetGeometries.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Civi\Api4\Action\Address;
+
+use Civi\Api4\Generic\Result;
+
+/**
+ * Address GetGeometries action
+ * @method getGeometries()
+ */
+class GetGeometries extends \Civi\Api4\Generic\AbstractAction {
+
+  /**
+   * Address Id
+   * @var int
+   * @required
+   */
+  protected $address_id;
+
+  /**
+   * Geometry Id
+   * @var int
+   */
+  protected $geometry_id;
+
+  /**
+   * Skip cache
+   * @var bool
+   */
+  protected $skip_cache;
+
+  public function _run(Result $result) {
+    if (!empty($this->skip_cache)) {
+      $address = \Civi\Api4\Address::get(FALSE)
+        ->addSelect('id', 'geo_code_1', 'geo_code_2')
+        ->addWhere('id', '=', $this->address_id)
+        ->setLimit(1)
+        ->execute()
+        ->first();
+      if (!empty($address['geo_code_1']) && !empty($address['geo_code_2'])) {
+        $addressGeoJson = 'POINT(' . $address['geo_code_2'] . ' ' . $address['geo_code_1'] . ')';
+        $geometries = \Civi\Api4\Geometry::contains(FALSE)
+          ->addWhere('geometry_a', '=', 0)
+          ->addWhere('geometry_b', '=', $addressGeoJson)
+          ->execute();
+        foreach ($geometries as $geometry) {
+          $result[] = [
+            'address_id' => $this->address_id,
+            'geometry_id' => $geometry->id,
+          ];
+        }
+      }
+    }
+    else {
+      $geometries = \Civi\Api4\Geometry:getEntity(FALSE)
+        ->addSelect('geometry_id')
+        ->addWhere('entity_table', '=', 'civicrm_address')
+        ->addWhere('entity_id', '=', $this->address_id)
+        ->execute();
+      while ($geometries->fetch()) {
+        $result[] = [
+          'id' => $geometries=>id,
+          'entity_id' => $geometries->entity_id,
+          'entity_table' =>'civicrm_address',
+          'geometry_id' => $geometries->geometry_id,
+        ];
+      }
+    }
+  }
+}

--- a/Civi/Api4/Action/Address/GetGeometries.php
+++ b/Civi/Api4/Action/Address/GetGeometries.php
@@ -57,12 +57,12 @@ class GetGeometries extends \Civi\Api4\Generic\AbstractAction {
         ->addWhere('entity_table', '=', 'civicrm_address')
         ->addWhere('entity_id', '=', $this->address_id)
         ->execute();
-      while ($geometries->fetch()) {
+      foreach ($geometries as $geometry) {
         $result[] = [
-          'id' => $geometries->id,
-          'entity_id' => $geometries->entity_id,
+          'id' => $geometry['id'],
+          'entity_id' => $geometry['entity_id'],
           'entity_table' =>'civicrm_address',
-          'geometry_id' => $geometries->geometry_id,
+          'geometry_id' => $geometry['geometry_id'],
         ];
       }
     }

--- a/Civi/Api4/Action/Geometry/GetEntity.php
+++ b/Civi/Api4/Action/Geometry/GetEntity.php
@@ -7,7 +7,7 @@ use CRM_CiviGeometry_ExtensionUtil as E;
 /**
  * Get GeometryEntity Records
  */
-class GetEntity extends \Civi\Api4\Generic\AbstractGetAction {
+class GetEntity extends \Civi\Api4\Generic\DAOGetAction {
 
   public function _run(Result $result) {
     $whereClauses = $this->getWhere();

--- a/Civi/Api4/Service/Spec/Provider/GeometryGetEntitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/GeometryGetEntitySpecProvider.php
@@ -17,7 +17,7 @@ class GeometryGetEntitySpecProvider implements Generic\SpecProviderInterface {
       ->setDescription('Entity ID that is linked to the geometry')
       ->setRequired(FALSE);
     $spec->addFieldSpec($entity_id);
-    $entity_table = new FieldSpec('entity_table', 'GeometryEntity', 'Integer');
+    $entity_table = new FieldSpec('entity_table', 'GeometryEntity', 'String');
     $entity_table->setTitle('Entity Table')
       ->setDescription('Entity Table for the entity that is linked to the geometry')
       ->setRequired(FALSE);

--- a/api/v3/Address/Creategeometries.php
+++ b/api/v3/Address/Creategeometries.php
@@ -29,6 +29,8 @@ function _civicrm_api3_address_creategeometries_spec(&$spec) {
 /**
  * Address.creategeometries API
  *
+ * @deprecated
+ *
  * @param array $params
  * @return array API result descriptor
  * @see civicrm_api3_create_success
@@ -36,6 +38,7 @@ function _civicrm_api3_address_creategeometries_spec(&$spec) {
  * @throws API_Exception
  */
 function civicrm_api3_address_creategeometries($params) {
+  CRM_Core_Error::deprecatedFunctionWarning('The address.creategeometries api is unsupported. Use APIv4 Geometry.createEntity instead');
   $params['entity_id'] = $params['address_id'];
   $params['entity_table'] = 'civicrm_address';
   return _civicrm_api3_basic_create('CRM_CiviGeometry_DAO_GeometryEntity', $params);

--- a/api/v3/Address/Getgeometries.php
+++ b/api/v3/Address/Getgeometries.php
@@ -41,7 +41,7 @@ function _civicrm_api3_address_getgeometries_spec(&$spec) {
  * @throws API_Exception
  */
 function civicrm_api3_address_getgeometries($params) {
-  CRM_Core_Error::depractedFunctionWarning('The address.getgeometries api is unsupported. Use the APIv4 Geometry.getEntity instead.');
+  CRM_Core_Error::deprecatedFunctionWarning('The address.getgeometries api is unsupported. Use the APIv4 Geometry.getEntity instead.');
   civicrm_api3_verify_one_mandatory($params, NULL, ['address_id', 'geometry_id']);
   if (!empty($params['skip_cache'])) {
     if (!empty($params['address_id'])) {

--- a/api/v3/Address/Getgeometries.php
+++ b/api/v3/Address/Getgeometries.php
@@ -32,6 +32,8 @@ function _civicrm_api3_address_getgeometries_spec(&$spec) {
 /**
  * Address.Getgeometries API
  *
+ * @deprecated
+ *
  * @param array $params
  * @return array API result descriptor
  * @see civicrm_api3_create_success
@@ -39,6 +41,7 @@ function _civicrm_api3_address_getgeometries_spec(&$spec) {
  * @throws API_Exception
  */
 function civicrm_api3_address_getgeometries($params) {
+  CRM_Core_Error::depractedFunctionWarning('The address.getgeometries api is unsupported. Use the APIv4 Geometry.getEntity instead.');
   civicrm_api3_verify_one_mandatory($params, NULL, ['address_id', 'geometry_id']);
   if (!empty($params['skip_cache'])) {
     if (!empty($params['address_id'])) {

--- a/api/v3/Geometry.php
+++ b/api/v3/Geometry.php
@@ -33,7 +33,7 @@ function civicrm_api3_geometry_create($params) {
   if (empty($params['id']) && empty($params['geometry'])) {
     throw new \API_Exception(E::ts('Geometry is required unless supplying an id to do an update'));
   }
-  if (isset($params['geomety']) && empty($params['geometry'])) {
+  if (isset($params['geometry']) && empty($params['geometry'])) {
     throw new \API_Exception(E::ts('Geometry was empty'));
   }
   if (isset($params['geometry_type_id']) && !CRM_Utils_Rule::Integer($params['geometry_type_id'])) {

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/australiangreens/au.org.greens.civigeometry</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2022-08-26</releaseDate>
-  <version>1.9.0</version>
+  <releaseDate>2023-07-19</releaseDate>
+  <version>1.10.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.13</ver>


### PR DESCRIPTION
This PR adds an APIv4 Address.getGeometries call to replace the v3 call of the same entity/action. The v3 method is marked as deprecated.

The PR also fixes a bug found in a v3 Geometry API call.

Everything has been tested in dev and this is ready to merge.