### PR TITLE
Add Apiv4 GeometryEntity entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes for the CiviGeometry extension will be noted here.
 
+## [1.11.0] - 2023-07-28
+### Added
+ - GeometryEntity APIv4 entity with basic CRUD methods
+### Fixed
+ - Bug in parsing of where clauses in APIv4 Geometry.getentity code
+
 ## [1.10.1] - 2023-07-19
 ### Added
  - Address.getgeometries APIv4 method

--- a/Civi/Api4/Action/Geometry/GetEntity.php
+++ b/Civi/Api4/Action/Geometry/GetEntity.php
@@ -22,7 +22,7 @@ class GetEntity extends \Civi\Api4\Generic\DAOGetAction {
         if (!empty($where)) {
           $where .= ' AND ';
         }
-        $where .= $whereClause[0] . $whereClause[1] . $value;
+        $where = \CRM_Contact_BAO_Query::buildClause($whereClause[0], $whereClause[1], $whereClause[2]);
       }
     }
     if (!empty($where)) {

--- a/Civi/Api4/GeometryEntity.php
+++ b/Civi/Api4/GeometryEntity.php
@@ -10,4 +10,11 @@ namespace Civi\Api4;
  */
 class GeometryEntity extends Generic\DAOEntity {
 
+  public static function permissions() {
+    return [
+      'default' => ['access geometry'],
+      'create' => [['administer geometry', 'administer civicrm']],
+      'delete' => [['administer geometry', 'administer civicrm']],
+    ];
+  }
 }

--- a/Civi/Api4/GeometryEntity.php
+++ b/Civi/Api4/GeometryEntity.php
@@ -1,0 +1,13 @@
+<?php
+namespace Civi\Api4;
+
+/**
+ * GeometryEntity entity.
+ *
+ * Provided by the CiviGeometry extension.
+ *
+ * @package Civi\Api4
+ */
+class GeometryEntity extends Generic\DAOEntity {
+
+}

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/australiangreens/au.org.greens.civigeometry</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2023-07-19</releaseDate>
-  <version>1.10.0</version>
+  <releaseDate>2023-07-27</releaseDate>
+  <version>1.10.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.13</ver>

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/australiangreens/au.org.greens.civigeometry</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2023-07-27</releaseDate>
-  <version>1.10.1</version>
+  <releaseDate>2023-07-28</releaseDate>
+  <version>1.11.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.13</ver>


### PR DESCRIPTION
This PR adds an APIv4 entity GeometryEntity with basic CRUD methods and fixes a bug in the parsing of where clauses in the Geometry.getEntity APIv4 method.

The addition of the GeometryEntity entity is to more easily facilitate complex queries involving joins, given the need to use `entity_id` and `entity_table` in the joins.

Tested in a dev environment and via REST API calls.