### PR TITLE
Switch createentity calls to Api4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes for the CiviGeometry extension will be noted here.
 
+## [1.13.0] - 2023-12-12
+### Changed
+ - geoplaceAddress task refactored to use APIv4 calls instead of APIv3
+
 ## [1.12.0] - 2023-08-01
 ### Added
  - Geometry.getcachedoverlaps APIv4 method

--- a/CRM/CiviGeometry/Tasks.php
+++ b/CRM/CiviGeometry/Tasks.php
@@ -29,10 +29,11 @@ class CRM_CiviGeometry_Tasks {
       ])['values'];
       if (!empty($geometry_ids)) {
         foreach ($geometry_ids as $geometry_id) {
-          civicrm_api3('Address', 'creategeometries', [
-            'address_id' => $address['id'],
-            'geometry_id' => $geometry_id,
-          ]);
+          \Civi\Api4\Geometry::createEntity(FALSE)
+            ->setEntity_id($address['id'])
+            ->setEntity_table('civicrm_address')
+            ->setGeometry_id($geometry_id)
+            ->execute();
         }
       }
       $addressObject = new CRM_Core_BAO_Address();
@@ -49,10 +50,11 @@ class CRM_CiviGeometry_Tasks {
    */
   public static function buildGeometryRelationships(CRM_Queue_TaskContext $ctx, $geometry_id) {
     foreach (CRM_CiviGeometry_BAO_Geometry::getAddresses($geometry_id) as $match) {
-      civicrm_api3('Address', 'creategeometries', [
-        'geometry_id' => $match['geometry_id'],
-        'address_id' => $match['address_id'],
-      ]);
+      \Civi\Api4\Geometry::createEntity(FALSE)
+        ->setEntity_id($match['address_id'])
+        ->setEntity_table('civicrm_address')
+        ->setGeometry_id($match['geometry_id'])
+        ->execute();
     }
     return TRUE;
   }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "composer/installers": "^1.6"
+    "composer/installers": "^1.6 || ^2.2"
   },
   "config": {
     "allow-plugins": {

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/australiangreens/au.org.greens.civigeometry</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2023-08-01</releaseDate>
-  <version>1.12.0</version>
+  <releaseDate>2023-12-12</releaseDate>
+  <version>1.13.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.45</ver>


### PR DESCRIPTION
This api call is deprecated, so this PR just updates the calls to Api4, saving us all warning notices.