### PR TITLE
Fix test to work on PHPunit9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes for the CiviGeometry extension will be noted here.
 
+## [1.14.1] - 2024-07-11
+### Fixed
+- Unit tests now work properly with PHPUnit 9
+
 ## [1.14.0] - 2024-07-11
 ### Added
 - GeometryEntity entity now permits joins to Address and Contact entities in SearchKit

--- a/info.xml
+++ b/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2024-07-11</releaseDate>
-  <version>1.14.0</version>
+  <version>1.14.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.51</ver>

--- a/tests/phpunit/api/v3/GeometryTest.php
+++ b/tests/phpunit/api/v3/GeometryTest.php
@@ -275,7 +275,7 @@ class api_v3_GeometryTest extends \PHPUnit\Framework\TestCase implements Headles
     ]);
     $this->assertEquals(2, $results['count']);
     $this->assertContains((string) $upperHouseDistrict['id'], $results['values'], $upperHouseDistrict['id'] . ' Not found in ' . json_encode($results['values']));
-    $this->assertContains($upperHouseDistrictMBR['id'], $results['values']);
+    $this->assertContains((string) $upperHouseDistrictMBR['id'], $results['values']);
     // Check that when we specify a collection that only contains the non MBR geometry that that is the only geometry returned
     $resultWithCollection = $this->callAPISuccess('Geometry', 'contains', [
       'geometry_a' => 0,
@@ -283,15 +283,15 @@ class api_v3_GeometryTest extends \PHPUnit\Framework\TestCase implements Headles
       'geometry_b' => 'POINT(147.2687833 -42.9771098)',
     ]);
     $this->assertEquals(1, $resultWithCollection['count']);
-    $this->assertContains($upperHouseDistrict['id'], $resultWithCollection['values']);
+    $this->assertContains((string) $upperHouseDistrict['id'], $resultWithCollection['values']);
     // Assert that the non MBR geometry contains its self and MBR
     $resultGeometryIdB = $this->callAPISuccess('Geometry', 'contains', [
       'geometry_a' => 0,
       'geometry_b' => $upperHouseDistrict['id'],
     ]);
     $this->assertEquals(2, $resultGeometryIdB['count']);
-    $this->assertContains($upperHouseDistrict['id'], $resultGeometryIdB['values']);
-    $this->assertContains($upperHouseDistrictMBR['id'], $resultGeometryIdB['values']);
+    $this->assertContains((string) $upperHouseDistrict['id'], $resultGeometryIdB['values']);
+    $this->assertContains((string) $upperHouseDistrictMBR['id'], $resultGeometryIdB['values']);
     $this->callAPISuccess('Geometry', 'delete', ['id' => $upperHouseDistrict['id']]);
     $this->callAPISuccess('Geometry', 'delete', ['id' => $upperHouseDistrictMBR['id']]);
     $this->callAPISuccess('GeometryCollection', 'delete', ['id' => $UHCollection['id']]);

--- a/tests/phpunit/api/v3/GeometryTest.php
+++ b/tests/phpunit/api/v3/GeometryTest.php
@@ -274,7 +274,7 @@ class api_v3_GeometryTest extends \PHPUnit\Framework\TestCase implements Headles
       'geometry_b' => 'POINT(147.2687833 -42.9771098)',
     ]);
     $this->assertEquals(2, $results['count']);
-    $this->assertContains($upperHouseDistrict['id'], $results['values'], $upperHouseDistrict['id'] . ' Not found in ' . json_encode($results['values']));
+    $this->assertContains((string) $upperHouseDistrict['id'], $results['values'], $upperHouseDistrict['id'] . ' Not found in ' . json_encode($results['values']));
     $this->assertContains($upperHouseDistrictMBR['id'], $results['values']);
     // Check that when we specify a collection that only contains the non MBR geometry that that is the only geometry returned
     $resultWithCollection = $this->callAPISuccess('Geometry', 'contains', [


### PR DESCRIPTION
PHPUnit9 does actual type comparison as well as value so in this case we were having strings in the values array but comparing to an int.  This fixes it compare https://buildkite.com/greens/au-dot-org-dot-greens-dot-civigeometry/builds/392 to https://buildkite.com/greens/au-dot-org-dot-greens-dot-civigeometry/builds/397