### PR TITLE
Ref/optimisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes for the CiviGeometry extension will be noted here.
 
+## [2.1.0] - 2026-02-10
+### Changed
+- the code to find all addresses contained by a geometry now batches its operations
+  to reduce the number of database queries the code makes.
+- replace chained APIv3 calls to delete geometry-entity relationships with more direct
+  database queries for performance
+
 ## [2.0.0] - 2024-10-08
 ### Changed
 - BREAKING: The extension now uses Entity Framework version 2. This limits use of

--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -116,7 +116,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
       ];
     }
 
-    $result = CRM_Core_DAO::executeQuery("SELECT $selectStr FROM $fromStr WHERE $whereStr FOR UPDATE", $sqlParams);
+    $result = CRM_Core_DAO::executeQuery("SELECT SQL_NO_CACHE $selectStr FROM $fromStr WHERE $whereStr", $sqlParams);
 
     // The above query will return a single result if both geoms exist, 0 results if one does not
     return $result->fetch()
@@ -171,7 +171,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
       }
     }
 
-    $res = CRM_Core_DAO::executeQuery("SELECT $selectStr FROM $fromStr WHERE $whereStr FOR UPDATE", $queryParams);
+    $res = CRM_Core_DAO::executeQuery("SELECT SQL_NO_CACHE $selectStr FROM $fromStr WHERE $whereStr", $queryParams);
 
     return array_column($res->fetchAll(), 'id');
   }
@@ -265,11 +265,10 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
       else {
         $query_params[1] = [$params['geometry_a'], 'Positive'];
       }
-      $geometries = CRM_Core_DAO::executeQuery("SELECT {$select_table}.id
+      $geometries = CRM_Core_DAO::executeQuery("SELECT SQL_NO_CACHE {$select_table}.id
         FROM civigeometry_geometry {$where_table}, civigeometry_geometry as {$select_table}
         INNER JOIN civigeometry_geometry_collection_geometry cgc ON cgc.geometry_id = {$select_table}.id
-        WHERE {$where_table}.id = %1 AND cgc.collection_id = %2 AND ST_Intersects(a.geometry, b.geometry) != 0
-        FOR UPDATE", $query_params)->fetchAll();
+        WHERE {$where_table}.id = %1 AND cgc.collection_id = %2 AND ST_Intersects(a.geometry, b.geometry) != 0", $query_params)->fetchAll();
       foreach ($geometries as $geometry_id) {
         if ($select_table === 'a') {
           $values[] = [
@@ -286,9 +285,9 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
       }
     }
     else {
-      $intersection = CRM_Core_DAO::singleValueQuery("SELECT ST_Intersects(a.geometry, b.geometry)
+      $intersection = CRM_Core_DAO::singleValueQuery("SELECT SQL_NO_CACHE ST_Intersects(a.geometry, b.geometry)
         FROM civigeometry_geometry a, civigeometry_geometry b
-        WHERE a.id = %1 AND b.id = %2 FOR UPDATE", [
+        WHERE a.id = %1 AND b.id = %2", [
           1 => [$params['geometry_a'], 'Positive'],
           2 => [$params['geometry_b'], 'Positive'],
         ]);
@@ -354,9 +353,9 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
       }
     }
     $intersectionArea = CRM_Core_DAO::executeQuery("
-      SELECT ST_Area(a.geometry) as area, ST_Area(ST_Intersection(a.geometry, b.geometry)) as intersection_area
+      SELECT SQL_NO_CACHE ST_Area(a.geometry) as area, ST_Area(ST_Intersection(a.geometry, b.geometry)) as intersection_area
       FROM civigeometry_geometry a, civigeometry_geometry b
-      WHERE a.id = %1 AND b.id = %2 FOR UPDATE", [
+      WHERE a.id = %1 AND b.id = %2", [
         1 => [$params['geometry_id_a'], 'Positive'],
         2 => [$params['geometry_id_b'], 'Positive'],
       ]);
@@ -391,7 +390,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
    */
   public static function calculateDistance($params) {
     // We use SRID 4326 or WGS84 (SRID 4326) This is the standard projection used in google maps etc
-    $result = CRM_Core_DAO::singleValueQuery("SELECT earth_circle_distance(ST_GeomFromText(%1, 4326), ST_GeomFromText(%2, 4326)) FOR UPDATE", [
+    $result = CRM_Core_DAO::singleValueQuery("SELECT SQL_NO_CACHE earth_circle_distance(ST_GeomFromText(%1, 4326), ST_GeomFromText(%2, 4326))", [
       1 => [$params['geometry_a'], 'String'],
       2 => [$params['geometry_b'], 'String'],
     ]);
@@ -464,9 +463,8 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
    */
   public static function buildAddressRelationshipsBatch($geometry_id) {
     $bounds = self::generateBounds($geometry_id);
-    CRM_Core_DAO::executeQuery("
-      INSERT IGNORE INTO civigeometry_geometry_entity (entity_id, entity_table, geometry_id)
-      SELECT ca.id, 'civicrm_address', g.id
+    $dao = CRM_Core_DAO::executeQuery("
+      SELECT SQL_NO_CACHE ca.id
       FROM civicrm_address ca
       INNER JOIN civigeometry_geometry g ON g.id = %1
       WHERE ca.geo_code_1 IS NOT NULL
@@ -474,7 +472,6 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
         AND ca.geo_code_2 >= %2 AND ca.geo_code_2 <= %3
         AND ca.geo_code_1 >= %4 AND ca.geo_code_1 <= %5
         AND ST_Contains(g.geometry, ST_GeomFromText(CONCAT('POINT(', ca.geo_code_2, ' ', ca.geo_code_1, ')'), 4326))
-      FOR UPDATE
     ", [
       1 => [$geometry_id, 'Positive'],
       2 => [$bounds['left_bound'], 'Float'],
@@ -482,6 +479,16 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
       4 => [$bounds['bottom_bound'], 'Float'],
       5 => [$bounds['top_bound'], 'Float'],
     ]);
+    $addressIds = array_column($dao->fetchAll(), 'id');
+    if ($addressIds) {
+      $values = [];
+      foreach ($addressIds as $addressId) {
+        $values[] = '(' . (int) $addressId . ", 'civicrm_address', " . (int) $geometry_id . ')';
+      }
+      CRM_Core_DAO::executeQuery(
+        "INSERT IGNORE INTO civigeometry_geometry_entity (entity_id, entity_table, geometry_id) VALUES " . implode(',', $values)
+      );
+    }
   }
 
   /**
@@ -590,8 +597,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
 
     $tempTableName = $tmpTbl->getName();
     if ($params['precheck_relationships']) {
-      CRM_Core_DAO::executeQuery("
-        INSERT INTO $tempTableName (address_id)
+      $dao = CRM_Core_DAO::executeQuery("
         SELECT ca.id
         FROM
           civicrm_address ca
@@ -618,8 +624,7 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
       ]);
     }
     else {
-      CRM_Core_DAO::executeQuery("
-        INSERT INTO $tempTableName (address_id)
+      $dao = CRM_Core_DAO::executeQuery("
         SELECT ca.id
         FROM civicrm_address ca
         WHERE
@@ -635,6 +640,11 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
         4 => [$bounds['bottom_bound'], 'Float'],
       ]);
     }
+    $candidateIds = array_column($dao->fetchAll(), 'id');
+    if ($candidateIds) {
+      $values = implode(',', array_map(function($id) { return '(' . (int) $id . ')'; }, $candidateIds));
+      CRM_Core_DAO::executeQuery("INSERT INTO $tempTableName (address_id) VALUES $values");
+    }
 
     $numCandidates = CRM_Core_DAO::singleValueQuery("SELECT COUNT(*) FROM $tempTableName");
 
@@ -648,12 +658,11 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
         $idList = implode(',', array_map('intval', $candidateIds));
         $geomTableName = self::getTableName();
         $dao = CRM_Core_DAO::executeQuery("
-          SELECT ca.id AS address_id
+          SELECT SQL_NO_CACHE ca.id AS address_id
           FROM civicrm_address ca
           INNER JOIN $geomTableName g ON g.id = %1
           WHERE ca.id IN ($idList)
             AND ST_Contains(g.geometry, ST_GeomFromText(CONCAT('POINT(', ca.geo_code_2, ' ', ca.geo_code_1, ')'), 4326))
-          FOR UPDATE
         ", [
           1 => [$geometry_id, 'Integer'],
         ]);

--- a/CRM/CiviGeometry/BAO/Geometry.php
+++ b/CRM/CiviGeometry/BAO/Geometry.php
@@ -454,6 +454,37 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
   }
 
   /**
+   * Find all addresses contained by a geometry and insert relationships in bulk.
+   *
+   * Uses the geometry's bounding box to pre-filter candidates before ST_Contains,
+   * and INSERT IGNORE to skip any existing relationships.
+   *
+   * @param int $geometry_id
+   *   The id of the geometry to build relationships for.
+   */
+  public static function buildAddressRelationshipsBatch($geometry_id) {
+    $bounds = self::generateBounds($geometry_id);
+    CRM_Core_DAO::executeQuery("
+      INSERT IGNORE INTO civigeometry_geometry_entity (entity_id, entity_table, geometry_id)
+      SELECT ca.id, 'civicrm_address', g.id
+      FROM civicrm_address ca
+      INNER JOIN civigeometry_geometry g ON g.id = %1
+      WHERE ca.geo_code_1 IS NOT NULL
+        AND ca.geo_code_2 IS NOT NULL
+        AND ca.geo_code_2 >= %2 AND ca.geo_code_2 <= %3
+        AND ca.geo_code_1 >= %4 AND ca.geo_code_1 <= %5
+        AND ST_Contains(g.geometry, ST_GeomFromText(CONCAT('POINT(', ca.geo_code_2, ' ', ca.geo_code_1, ')'), 4326))
+      FOR UPDATE
+    ", [
+      1 => [$geometry_id, 'Positive'],
+      2 => [$bounds['left_bound'], 'Float'],
+      3 => [$bounds['right_bound'], 'Float'],
+      4 => [$bounds['bottom_bound'], 'Float'],
+      5 => [$bounds['top_bound'], 'Float'],
+    ]);
+  }
+
+  /**
    * Convert Wkt Geoemtry to KML
    * @param string $wkt
    * @see http://blog.mastermaps.com/2008/03/wkt-to-kml-transformation.html
@@ -517,28 +548,6 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
     $results = $dao->fetchAll();
 
     return $results;
-  }
-
-  /**
-   * Helper method for getAddresses. Checks if specified geometry contains civicrm_address with id.
-   *
-   * @param  integer $geometryId    Id of the geometry to check against
-   * @param  integer $addressId     Id of the civicrm_address
-   * @return boolean
-   */
-  protected static function getAddressesGeometryContainsCandidate($geometryId, $addressId) {
-    $geomTableName = self::getTableName();
-    $result = CRM_Core_DAO::singleValueQuery("
-      SELECT ST_Contains(g.geometry, ST_GeomFromText(CONCAT('POINT(', ca.geo_code_2, ' ', ca.geo_code_1, ')'), 4326))
-      FROM civicrm_address ca, $geomTableName g
-      WHERE g.id = %1 AND ca.id = %2
-      FOR UPDATE
-    ", [
-      1 => [$geometryId, 'Integer'],
-      2 => [$addressId, 'Integer'],
-    ]);
-
-    return boolval($result);
   }
 
   /**
@@ -635,10 +644,21 @@ class CRM_CiviGeometry_BAO_Geometry extends CRM_CiviGeometry_DAO_Geometry {
       $candidates = self::getAddressesFetchCandidateBatch($tempTableName, $offset, $params['batch_size']);
 
       if (count($candidates)) {
-        foreach ($candidates as $candidate) {
-          if (self::getAddressesGeometryContainsCandidate($geometry_id, $candidate['address_id'])) {
-            yield ['geometry_id' => $geometry_id, 'address_id' => $candidate['address_id']];
-          }
+        $candidateIds = array_column($candidates, 'address_id');
+        $idList = implode(',', array_map('intval', $candidateIds));
+        $geomTableName = self::getTableName();
+        $dao = CRM_Core_DAO::executeQuery("
+          SELECT ca.id AS address_id
+          FROM civicrm_address ca
+          INNER JOIN $geomTableName g ON g.id = %1
+          WHERE ca.id IN ($idList)
+            AND ST_Contains(g.geometry, ST_GeomFromText(CONCAT('POINT(', ca.geo_code_2, ' ', ca.geo_code_1, ')'), 4326))
+          FOR UPDATE
+        ", [
+          1 => [$geometry_id, 'Integer'],
+        ]);
+        while ($dao->fetch()) {
+          yield ['geometry_id' => $geometry_id, 'address_id' => $dao->address_id];
         }
 
         $offset += $params['batch_size'];

--- a/CRM/CiviGeometry/Tasks.php
+++ b/CRM/CiviGeometry/Tasks.php
@@ -21,19 +21,28 @@ class CRM_CiviGeometry_Tasks {
       ", [
         1 => [$address['id'], 'Positive'],
       ]);
-      // Find all containing geometries and insert relationships in one query
+      // Find all containing geometries, then insert relationships.
+      // Separated into SELECT + INSERT to avoid shared locks on civigeometry_geometry.
       $point = 'POINT(' . $address['geo_code_2'] . ' ' . $address['geo_code_1'] . ')';
-      CRM_Core_DAO::executeQuery("
-        INSERT IGNORE INTO civigeometry_geometry_entity (entity_id, entity_table, geometry_id)
-        SELECT %1, 'civicrm_address', g.id
+      $dao = CRM_Core_DAO::executeQuery("
+        SELECT SQL_NO_CACHE g.id
         FROM civigeometry_geometry g
         WHERE g.is_archived = 0
-          AND ST_Contains(g.geometry, ST_GeomFromText(%2, 4326))
-        FOR UPDATE
+          AND ST_Contains(g.geometry, ST_GeomFromText(%1, 4326))
       ", [
-        1 => [$address['id'], 'Positive'],
-        2 => [$point, 'String'],
+        1 => [$point, 'String'],
       ]);
+      $geometryIds = array_column($dao->fetchAll(), 'id');
+      if ($geometryIds) {
+        $addressId = (int) $address['id'];
+        $values = [];
+        foreach ($geometryIds as $geometryId) {
+          $values[] = '(' . $addressId . ", 'civicrm_address', " . (int) $geometryId . ')';
+        }
+        CRM_Core_DAO::executeQuery(
+          "INSERT IGNORE INTO civigeometry_geometry_entity (entity_id, entity_table, geometry_id) VALUES " . implode(',', $values)
+        );
+      }
       $addressObject = new CRM_Core_BAO_Address();
       $addressObject->id = $address['id'];
       $addressObject->find(TRUE);

--- a/CRM/CiviGeometry/Tasks.php
+++ b/CRM/CiviGeometry/Tasks.php
@@ -14,28 +14,26 @@ class CRM_CiviGeometry_Tasks {
       $address = FALSE;
     }
     if ($address) {
-      civicrm_api3('Geometry', 'getentity', [
-        'entity_id' => $address['id'],
-        'entity_table' => 'civicrm_address',
-        'api.Geometry.deleteentity' => [
-          'entity_id' => "\$value.entity_id",
-          'entity_table' => "\$value.entity_table",
-          'geometry_id' => "\$value.geometry_id",
-        ],
+      // Remove all existing geometry relationships for this address
+      CRM_Core_DAO::executeQuery("
+        DELETE FROM civigeometry_geometry_entity
+        WHERE entity_id = %1 AND entity_table = 'civicrm_address'
+      ", [
+        1 => [$address['id'], 'Positive'],
       ]);
-      $geometry_ids = civicrm_api3('Geometry', 'contains', [
-        'geometry_a' => 0,
-        'geometry_b' => 'POINT(' . $address['geo_code_2'] . ' ' . $address['geo_code_1'] . ')',
-      ])['values'];
-      if (!empty($geometry_ids)) {
-        foreach ($geometry_ids as $geometry_id) {
-          \Civi\Api4\Geometry::createEntity(FALSE)
-            ->setEntity_id($address['id'])
-            ->setEntity_table('civicrm_address')
-            ->setGeometry_id($geometry_id)
-            ->execute();
-        }
-      }
+      // Find all containing geometries and insert relationships in one query
+      $point = 'POINT(' . $address['geo_code_2'] . ' ' . $address['geo_code_1'] . ')';
+      CRM_Core_DAO::executeQuery("
+        INSERT IGNORE INTO civigeometry_geometry_entity (entity_id, entity_table, geometry_id)
+        SELECT %1, 'civicrm_address', g.id
+        FROM civigeometry_geometry g
+        WHERE g.is_archived = 0
+          AND ST_Contains(g.geometry, ST_GeomFromText(%2, 4326))
+        FOR UPDATE
+      ", [
+        1 => [$address['id'], 'Positive'],
+        2 => [$point, 'String'],
+      ]);
       $addressObject = new CRM_Core_BAO_Address();
       $addressObject->id = $address['id'];
       $addressObject->find(TRUE);
@@ -49,13 +47,7 @@ class CRM_CiviGeometry_Tasks {
    * Get all the Addresses for this geometry
    */
   public static function buildGeometryRelationships(CRM_Queue_TaskContext $ctx, $geometry_id) {
-    foreach (CRM_CiviGeometry_BAO_Geometry::getAddresses($geometry_id) as $match) {
-      \Civi\Api4\Geometry::createEntity(FALSE)
-        ->setEntity_id($match['address_id'])
-        ->setEntity_table('civicrm_address')
-        ->setGeometry_id($match['geometry_id'])
-        ->execute();
-    }
+    CRM_CiviGeometry_BAO_Geometry::buildAddressRelationshipsBatch($geometry_id);
     return TRUE;
   }
 

--- a/Civi/Api4/Action/Geometry/GetEntity.php
+++ b/Civi/Api4/Action/Geometry/GetEntity.php
@@ -22,7 +22,7 @@ class GetEntity extends \Civi\Api4\Generic\DAOGetAction {
         if (!empty($where)) {
           $where .= ' AND ';
         }
-        $where .= \CRM_Contact_BAO_Query::buildClause($whereClause[0], $whereClause[1], $whereClause[2]);
+        $where .= \CRM_Contact_BAO_Query::buildClause($whereClause[0], $whereClause[1], $value);
       }
     }
     if (!empty($where)) {

--- a/Civi/Api4/Action/Geometry/GetEntity.php
+++ b/Civi/Api4/Action/Geometry/GetEntity.php
@@ -11,30 +11,36 @@ class GetEntity extends \Civi\Api4\Generic\DAOGetAction {
 
   public function _run(Result $result) {
     $whereClauses = $this->getWhere();
-    $query = 'SELECT * FROM ' . \CRM_CiviGeometry_DAO_GeometryEntity::getTableName();
-    $where = '';
+    $tableName = \CRM_CiviGeometry_DAO_GeometryEntity::getTableName();
+    $query = "SELECT * FROM {$tableName}";
+  
+    $conditions = [];
+    $allowedFields = ['entity_id', 'entity_table', 'geometry_id', 'expiry_date'];
+
     foreach ($whereClauses as $whereClause) {
-      if (in_array($whereClause[0], ['entity_id', 'entity_table', 'geometry_id', 'expiry_date'])) {
-        $value = $whereClause[2];
-        if ($whereClause[0] === 'expiry_date') {
-          $value = \CRM_Utils_Date::isoToMysql($value);
-        }
-        if (!empty($where)) {
-          $where .= ' AND ';
-        }
-        $where .= \CRM_Contact_BAO_Query::buildClause($whereClause[0], $whereClause[1], $value);
+      [$field, $operator, $rawValue] = $whereClause;
+  
+      if (in_array($field, $allowedFields)) {
+        $value = ($field === 'expiry_date') 
+          ? \CRM_Utils_Date::isoToMysql($rawValue) 
+          : $rawValue;
+  
+        $conditions[] = \CRM_Contact_BAO_Query::buildClause($field, $operator, $value);
       }
     }
-    if (!empty($where)) {
-      $query .= ' WHERE ' . $where;
+
+    if (!empty($conditions)) {
+      $query .= ' WHERE ' . implode(' AND ', $conditions);
     }
+  
     $results = \CRM_Core_DAO::executeQuery($query);
+  
     while ($results->fetch()) {
       $result[] = [
-        'id' => $results->id,
-        'entity_id' => $results->entity_id,
+        'id'           => $results->id,
+        'entity_id'    => $results->entity_id,
         'entity_table' => $results->entity_table,
-        'geometry_id' => $results->geometry_id,
+        'geometry_id'  => $results->geometry_id,
       ];
     }
   }

--- a/Civi/Api4/Action/Geometry/GetEntity.php
+++ b/Civi/Api4/Action/Geometry/GetEntity.php
@@ -14,7 +14,7 @@ class GetEntity extends \Civi\Api4\Generic\DAOGetAction {
     $query = 'SELECT * FROM ' . \CRM_CiviGeometry_DAO_GeometryEntity::getTableName();
     $where = '';
     foreach ($whereClauses as $whereClause) {
-      if (in_array($whereClause[0], ['entity_id', 'entity_Table', 'geometry_id', 'expiry_date'])) {
+      if (in_array($whereClause[0], ['entity_id', 'entity_table', 'geometry_id', 'expiry_date'])) {
         $value = $whereClause[2];
         if ($whereClause[0] === 'expiry_date') {
           $value = \CRM_Utils_Date::isoToMysql($value);
@@ -22,7 +22,7 @@ class GetEntity extends \Civi\Api4\Generic\DAOGetAction {
         if (!empty($where)) {
           $where .= ' AND ';
         }
-        $where = \CRM_Contact_BAO_Query::buildClause($whereClause[0], $whereClause[1], $whereClause[2]);
+        $where .= \CRM_Contact_BAO_Query::buildClause($whereClause[0], $whereClause[1], $whereClause[2]);
       }
     }
     if (!empty($where)) {

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/australiangreens/au.org.greens.civigeometry</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-10-08</releaseDate>
-  <version>2.0.0</version>
+  <releaseDate>2026-02-10</releaseDate>
+  <version>2.1.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.51</ver>


### PR DESCRIPTION
This PR makes a few changes to improve query performance and fix issues:

## Changes

**Civi/Api4/Action/Geometry/GetEntity.php**
This function has been rewritten to address a few concerns. Critically, the function contained bugs; the old line `$where = \CRM_Contact_BAO_Query` would overwrite any previously built clauses.

**CRM/CiviGeometry/BAO/Geometry.php**
Added a batch function for building address-geometry relationships. This function replaces the getAddresses() + per-row createEntity loop with a single query. You see the utilisation of this in the other changed file...

**CRM/CiviGeometry/Tasks.php**
Here's where we're really making use of the new function. `buildGeometryRelationships` no longer loops over `CRM_CiviGeometry_BAO_Geometry::getAddresses($geometry_id) as $match`. Instead it calls the batch function once.

We're also cleaning up `geoplaceAddress`; the old code has this flow:

`fetch existing → chained API delete each → find containing → API insert each`

The refactor reduces the number of queries against the database dramatically.

## Testing

All existing phpunit tests pass. The tests explicitly target APIv3 methods but they're in turn calling the functions that have been modified.

## Additional notes

We're still using the `FOR UPDATE` pattern because MariaDB has an ongoing issue with its query cache. Refactoring to remove `FOR UPDATE` would improve performance but I'll consider that separately. I believe the pattern is to use `SELECT_NO_CACHE` in the queries.