### PR TITLE
Fix bugs

### DIFF
--- a/Civi/Api4/Action/Geometry/GetIntersection.php
+++ b/Civi/Api4/Action/Geometry/GetIntersection.php
@@ -26,7 +26,7 @@ class GetIntersection extends \Civi\Api4\Generic\AbstractAction {
    * Geometry Id b
    * @var int
    */
-  protected $geoemtry_b;
+  protected $geometry_b;
 
   /**
    * Geometry B/A Collection ID
@@ -47,7 +47,7 @@ class GetIntersection extends \Civi\Api4\Generic\AbstractAction {
       $test = 'a';
     }
     // Check that we have either the other geometry or a collection id.
-    if (empty($this->geometry_{$test}) && empty($this->collection_id)) {
+    if (empty($this->{'geometry_' . $test}) && empty($this->collection_id)) {
       throw new \API_Exception('Must supply either geometry_' . $test . ' OR collection_id');
     }
     $params = [

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/australiangreens/au.org.greens.civigeometry</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-10-08</releaseDate>
-  <version>2.0.0</version>
+  <releaseDate>2026-06-01</releaseDate>
+  <version>2.0.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.51</ver>


### PR DESCRIPTION
This PR fixes two bugs: a misnamed variable and a deprecated syntax regarding string interpolation.

I used PHPCS to test the codebase for issues, and tested that the API method works via the CiviCRM API explorer.

The change is backwards compatible with PHP version 8.2+ at least, so is safe to deploy asap.